### PR TITLE
[feat] 에러 응답, 에러 코드 및 커스텀 에러 정의

### DIFF
--- a/src/main/java/com/tenten/damoa/common/exception/BusinessException.java
+++ b/src/main/java/com/tenten/damoa/common/exception/BusinessException.java
@@ -1,0 +1,34 @@
+package com.tenten.damoa.common.exception;
+
+import lombok.Getter;
+
+@Getter
+public class BusinessException extends RuntimeException{
+
+    private final ErrorCode errorCode;
+    private final String detail;
+
+    public BusinessException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+        this.detail = null;
+    }
+
+    public BusinessException(ErrorCode errorCode, Throwable cause) {
+        super(errorCode.getMessage(), cause);
+        this.errorCode = errorCode;
+        this.detail = null;
+    }
+
+    public BusinessException(ErrorCode errorCode, String detail) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+        this.detail = detail;
+    }
+
+    public BusinessException(ErrorCode errorCode, Throwable cause, String detail) {
+        super(errorCode.getMessage(), cause);
+        this.errorCode = errorCode;
+        this.detail = detail;
+    }
+}

--- a/src/main/java/com/tenten/damoa/common/exception/ErrorCode.java
+++ b/src/main/java/com/tenten/damoa/common/exception/ErrorCode.java
@@ -1,0 +1,19 @@
+package com.tenten.damoa.common.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorCode {
+
+    /**
+     * 500 - Internal Server Error
+     */
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 에러가 발생했습니다.")
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/src/main/java/com/tenten/damoa/common/exception/ErrorResponse.java
+++ b/src/main/java/com/tenten/damoa/common/exception/ErrorResponse.java
@@ -1,0 +1,21 @@
+package com.tenten.damoa.common.exception;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import org.springframework.http.ResponseEntity;
+
+public record ErrorResponse<T>(
+        String message,
+        @JsonInclude(value = JsonInclude.Include.NON_NULL)
+        T detail
+) {
+
+    public static ResponseEntity<ErrorResponse<Void>> toResponseEntity(ErrorCode errorCode) {
+        return ResponseEntity.status(errorCode.getHttpStatus())
+                .body(new ErrorResponse<>(errorCode.getMessage(), null));
+    }
+
+    public static <T> ResponseEntity<ErrorResponse<T>> toResponseEntity(ErrorCode errorCode, T detail) {
+        return ResponseEntity.status(errorCode.getHttpStatus())
+                .body(new ErrorResponse<>(errorCode.getMessage(), detail));
+    }
+}


### PR DESCRIPTION
## 🔥 구현 기능
> 에러가 발생했을 시에 전달할 응답, 코드, 커스텀 에러를 정의했습니다.

## 🔥 구현 방법
- 에러 발생 시 Exception Handler에서 사용할 에러 응답 클래스를 구현했습니다.
- 필드인 message는 Error Code에 정의한 메세지입니다.
- 필드인 detail은 추가로 제공할 정보입니다 ( 상세 에러 메시지 혹은 binding result 등등)
- BusinessException은 커스텀 에러로 이후에 비즈니스 로직에서 발생하는 예외를 처리하실 때 상속받아 사용하시면 좋을 것 같습니다!

## 🔥 참고할만한 자료
- 성공 응답시
    ```java
    return ResponseEntity.ok().body(response);
    ```
- 실패 응답시
    
    ```java
    return ErrorResponse.toResponseEntity(errorcode);
    ```
