### PR TITLE
[feat] entity, repository 생성

### DIFF
--- a/src/main/java/com/tenten/damoa/DamoaApplication.java
+++ b/src/main/java/com/tenten/damoa/DamoaApplication.java
@@ -2,7 +2,9 @@ package com.tenten.damoa;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class DamoaApplication {
 

--- a/src/main/java/com/tenten/damoa/common/model/BaseEntity.java
+++ b/src/main/java/com/tenten/damoa/common/model/BaseEntity.java
@@ -1,0 +1,23 @@
+package com.tenten.damoa.common.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Getter
+@EntityListeners(AuditingEntityListener.class)
+@MappedSuperclass
+public abstract class BaseEntity {
+
+    @Column(updatable = false)
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/tenten/damoa/hashtag/domain/Hashtag.java
+++ b/src/main/java/com/tenten/damoa/hashtag/domain/Hashtag.java
@@ -1,0 +1,32 @@
+package com.tenten.damoa.hashtag.domain;
+
+import com.tenten.damoa.post.domain.Post;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import java.time.LocalDateTime;
+import lombok.Getter;
+
+@Entity
+@Getter
+public class Hashtag {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String tag;
+
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id")
+    private Post post;
+}

--- a/src/main/java/com/tenten/damoa/hashtag/repository/HashtagRepository.java
+++ b/src/main/java/com/tenten/damoa/hashtag/repository/HashtagRepository.java
@@ -1,0 +1,8 @@
+package com.tenten.damoa.hashtag.repository;
+
+import com.tenten.damoa.hashtag.domain.Hashtag;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface HashtagRepository extends JpaRepository<Hashtag, Long> {
+
+}

--- a/src/main/java/com/tenten/damoa/interactionhistory/domain/Category.java
+++ b/src/main/java/com/tenten/damoa/interactionhistory/domain/Category.java
@@ -1,0 +1,7 @@
+package com.tenten.damoa.interactionhistory.domain;
+
+public enum Category {
+    VIEW,
+    LIKE,
+    SHARE
+}

--- a/src/main/java/com/tenten/damoa/interactionhistory/domain/InteractionHistory.java
+++ b/src/main/java/com/tenten/damoa/interactionhistory/domain/InteractionHistory.java
@@ -1,0 +1,35 @@
+package com.tenten.damoa.interactionhistory.domain;
+
+import com.tenten.damoa.post.domain.Post;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import java.time.LocalDateTime;
+import lombok.Getter;
+
+@Entity
+@Getter
+public class InteractionHistory {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    @Enumerated(value = EnumType.STRING)
+    private Category category;
+
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id")
+    private Post post;
+}

--- a/src/main/java/com/tenten/damoa/interactionhistory/repository/InteractionHistoryRepository.java
+++ b/src/main/java/com/tenten/damoa/interactionhistory/repository/InteractionHistoryRepository.java
@@ -1,0 +1,8 @@
+package com.tenten.damoa.interactionhistory.repository;
+
+import com.tenten.damoa.interactionhistory.domain.InteractionHistory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface InteractionHistoryRepository extends JpaRepository<InteractionHistory, Long> {
+
+}

--- a/src/main/java/com/tenten/damoa/member/domain/Member.java
+++ b/src/main/java/com/tenten/damoa/member/domain/Member.java
@@ -15,8 +15,8 @@ import lombok.Getter;
 public class Member {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private String id;
 
     @Column(nullable = false)
     private String account;

--- a/src/main/java/com/tenten/damoa/member/domain/Member.java
+++ b/src/main/java/com/tenten/damoa/member/domain/Member.java
@@ -1,0 +1,36 @@
+package com.tenten.damoa.member.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import java.time.LocalDateTime;
+import lombok.Getter;
+
+@Entity
+@Getter
+public class Member {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String account;
+
+    @Column(nullable = false)
+    private String email;
+
+    @Column(nullable = false)
+    private String password;
+
+    @Column(nullable = false)
+    @Enumerated(value = EnumType.STRING)
+    private MemberRole role;
+
+    @Column(nullable = false)
+    private LocalDateTime joinedAt;
+}

--- a/src/main/java/com/tenten/damoa/member/domain/MemberRole.java
+++ b/src/main/java/com/tenten/damoa/member/domain/MemberRole.java
@@ -1,0 +1,5 @@
+package com.tenten.damoa.member.domain;
+
+public enum MemberRole {
+    PRE_MEMBER, MEMBER
+}

--- a/src/main/java/com/tenten/damoa/member/repository/MemberRepository.java
+++ b/src/main/java/com/tenten/damoa/member/repository/MemberRepository.java
@@ -1,0 +1,8 @@
+package com.tenten.damoa.member.repository;
+
+import com.tenten.damoa.member.domain.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+
+}

--- a/src/main/java/com/tenten/damoa/post/domain/Post.java
+++ b/src/main/java/com/tenten/damoa/post/domain/Post.java
@@ -1,0 +1,42 @@
+package com.tenten.damoa.post.domain;
+
+import com.tenten.damoa.common.model.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.Getter;
+
+@Entity
+@Getter
+public class Post extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String contentId;
+
+    @Column(nullable = false)
+    @Enumerated(value = EnumType.STRING)
+    private SnsType type;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Column(nullable = false)
+    private String content;
+
+    @Column(nullable = false)
+    private int viewCount;
+
+    @Column(nullable = false)
+    private int likeCount;
+
+    @Column(nullable = false)
+    private int shareCount;
+}

--- a/src/main/java/com/tenten/damoa/post/domain/SnsType.java
+++ b/src/main/java/com/tenten/damoa/post/domain/SnsType.java
@@ -1,0 +1,8 @@
+package com.tenten.damoa.post.domain;
+
+public enum SnsType {
+    FACEBOOK,
+    TWITTER,
+    INSTAGRAM,
+    THREADS,
+}

--- a/src/main/java/com/tenten/damoa/post/repository/PostRepository.java
+++ b/src/main/java/com/tenten/damoa/post/repository/PostRepository.java
@@ -1,0 +1,8 @@
+package com.tenten.damoa.post.repository;
+
+import com.tenten.damoa.post.domain.Post;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PostRepository extends JpaRepository<Post, Long> {
+
+}

--- a/src/main/java/com/tenten/damoa/verificationcode/domain/VerificationCode.java
+++ b/src/main/java/com/tenten/damoa/verificationcode/domain/VerificationCode.java
@@ -1,0 +1,32 @@
+package com.tenten.damoa.verificationcode.domain;
+
+import com.tenten.damoa.member.domain.Member;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import java.time.LocalDateTime;
+import lombok.Getter;
+
+@Entity
+@Getter
+public class VerificationCode {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String code;
+
+    @Column(nullable = false)
+    private LocalDateTime sendAt;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+}

--- a/src/main/java/com/tenten/damoa/verificationcode/repository/VerificationCodeRepository.java
+++ b/src/main/java/com/tenten/damoa/verificationcode/repository/VerificationCodeRepository.java
@@ -1,0 +1,8 @@
+package com.tenten.damoa.verificationcode.repository;
+
+import com.tenten.damoa.verificationcode.domain.VerificationCode;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface VerificationCodeRepository extends JpaRepository<VerificationCode, Long> {
+
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -2,7 +2,7 @@ spring:
   config:
     import: application-secret.properties
   datasource:
-    url: jdbc:h2:mem:testdb;DATABASE_TO_UPPER=false;MODE=MYSQL
+    url: jdbc:h2:mem:testdb;MODE=MYSQL
     username: sa
     password:
     driver-class-name: org.h2.Driver

--- a/src/main/resources/db/migration/V1__init.sql
+++ b/src/main/resources/db/migration/V1__init.sql
@@ -1,7 +1,7 @@
 CREATE TABLE IF NOT EXISTS member
 (
-    id        BIGINT PRIMARY KEY,
-    account   VARCHAR(20) UNIQUE NOT NULL,
+    id        BIGINT AUTO_INCREMENT PRIMARY KEY,
+    account   VARCHAR(50) UNIQUE NOT NULL,
     email     VARCHAR(100)       NOT NULL,
     password  VARCHAR(255)       NOT NULL,
     role      VARCHAR(50)        NOT NULL,
@@ -10,7 +10,7 @@ CREATE TABLE IF NOT EXISTS member
 
 CREATE TABLE IF NOT EXISTS verification_code
 (
-    id        BIGINT PRIMARY KEY,
+    id        BIGINT AUTO_INCREMENT PRIMARY KEY,
     code      VARCHAR(6)   NOT NULL,
     send_at   TIMESTAMP(6) NOT NULL,
     member_id BIGINT       NOT NULL,
@@ -19,7 +19,7 @@ CREATE TABLE IF NOT EXISTS verification_code
 
 CREATE TABLE IF NOT EXISTS post
 (
-    id          BIGINT PRIMARY KEY,
+    id          BIGINT AUTO_INCREMENT PRIMARY KEY,
     content_id  VARCHAR(255) NOT NULL,
     type        VARCHAR(50)  NOT NULL,
     title       VARCHAR(255) NOT NULL,
@@ -33,7 +33,7 @@ CREATE TABLE IF NOT EXISTS post
 
 CREATE TABLE IF NOT EXISTS hashtag
 (
-    id         BIGINT PRIMARY KEY,
+    id         BIGINT AUTO_INCREMENT PRIMARY KEY,
     tag        VARCHAR(50)  NOT NULL,
     created_at TIMESTAMP(6) NOT NULL,
     post_id    BIGINT       NOT NULL,
@@ -42,7 +42,7 @@ CREATE TABLE IF NOT EXISTS hashtag
 
 CREATE TABLE IF NOT EXISTS interaction_history
 (
-    id         BIGINT PRIMARY KEY,
+    id         BIGINT AUTO_INCREMENT PRIMARY KEY,
     category   VARCHAR(50)  NOT NULL,
     created_at TIMESTAMP(6) NOT NULL,
     post_id    BIGINT       NOT NULL,

--- a/src/main/resources/db/migration/V1__init.sql
+++ b/src/main/resources/db/migration/V1__init.sql
@@ -1,0 +1,50 @@
+CREATE TABLE IF NOT EXISTS member
+(
+    id        BIGINT PRIMARY KEY,
+    account   VARCHAR(20) UNIQUE NOT NULL,
+    email     VARCHAR(100)       NOT NULL,
+    password  VARCHAR(255)       NOT NULL,
+    role      VARCHAR(50)        NOT NULL,
+    joined_at TIMESTAMP(6)       NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS verification_code
+(
+    id        BIGINT PRIMARY KEY,
+    code      VARCHAR(6)   NOT NULL,
+    send_at   TIMESTAMP(6) NOT NULL,
+    member_id BIGINT       NOT NULL,
+    CONSTRAINT fk_member_verification_code FOREIGN KEY (member_id) REFERENCES member (id)
+);
+
+CREATE TABLE IF NOT EXISTS post
+(
+    id          BIGINT PRIMARY KEY,
+    content_id  VARCHAR(255) NOT NULL,
+    type        VARCHAR(50)  NOT NULL,
+    title       VARCHAR(255) NOT NULL,
+    content     VARCHAR(255) NOT NULL,
+    view_count  INT          NOT NULL,
+    like_count  INT          NOT NULL,
+    share_count INT          NOT NULL,
+    created_at  TIMESTAMP(6) NOT NULL,
+    updated_at  TIMESTAMP(6) NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS hashtag
+(
+    id         BIGINT PRIMARY KEY,
+    tag        VARCHAR(50)  NOT NULL,
+    created_at TIMESTAMP(6) NOT NULL,
+    post_id    BIGINT       NOT NULL,
+    CONSTRAINT fk_post_hashtag FOREIGN KEY (post_id) REFERENCES post (id)
+);
+
+CREATE TABLE IF NOT EXISTS interaction_history
+(
+    id         BIGINT PRIMARY KEY,
+    category   VARCHAR(50)  NOT NULL,
+    created_at TIMESTAMP(6) NOT NULL,
+    post_id    BIGINT       NOT NULL,
+    CONSTRAINT fk_post_interaction_history FOREIGN KEY (post_id) REFERENCES post (id)
+);

--- a/src/main/resources/db/migration/V1__init.sql
+++ b/src/main/resources/db/migration/V1__init.sql
@@ -1,6 +1,6 @@
 CREATE TABLE IF NOT EXISTS member
 (
-    id        BIGINT AUTO_INCREMENT PRIMARY KEY,
+    id        VARCHAR(255) DEFAULT (UUID()) PRIMARY KEY,
     account   VARCHAR(50) UNIQUE NOT NULL,
     email     VARCHAR(100)       NOT NULL,
     password  VARCHAR(255)       NOT NULL,
@@ -13,7 +13,7 @@ CREATE TABLE IF NOT EXISTS verification_code
     id        BIGINT AUTO_INCREMENT PRIMARY KEY,
     code      VARCHAR(6)   NOT NULL,
     send_at   TIMESTAMP(6) NOT NULL,
-    member_id BIGINT       NOT NULL,
+    member_id VARCHAR(255) NOT NULL,
     CONSTRAINT fk_member_verification_code FOREIGN KEY (member_id) REFERENCES member (id)
 );
 


### PR DESCRIPTION
## 🔥 구현 기능
> 사용자, 인증코드, 게시물, 해시태그, 상호작용 이력 엔티티, 레포지토리를 생성하였습니다.

## 🔥 구현 방법
게시물의 경우 BaseEntity를 상속받도록 하였습니다.

## 🔥 관련 이슈
related: #15 
    
## 참고 할만한 자료(선택)
