### PR TITLE
[refactor] 도메인 패키지, 클래스 이름 재정의

### DIFF
--- a/src/main/java/com/tenten/damoa/interaction/domain/InteractionCategory.java
+++ b/src/main/java/com/tenten/damoa/interaction/domain/InteractionCategory.java
@@ -1,4 +1,4 @@
-package com.tenten.damoa.interactionhistory.domain;
+package com.tenten.damoa.interaction.domain;
 
 public enum InteractionCategory {
     VIEW,

--- a/src/main/java/com/tenten/damoa/interaction/domain/InteractionHistory.java
+++ b/src/main/java/com/tenten/damoa/interaction/domain/InteractionHistory.java
@@ -1,4 +1,4 @@
-package com.tenten.damoa.interactionhistory.domain;
+package com.tenten.damoa.interaction.domain;
 
 import com.tenten.damoa.post.domain.Post;
 import jakarta.persistence.Column;

--- a/src/main/java/com/tenten/damoa/interaction/repository/InteractionHistoryRepository.java
+++ b/src/main/java/com/tenten/damoa/interaction/repository/InteractionHistoryRepository.java
@@ -1,6 +1,6 @@
-package com.tenten.damoa.interactionhistory.repository;
+package com.tenten.damoa.interaction.repository;
 
-import com.tenten.damoa.interactionhistory.domain.InteractionHistory;
+import com.tenten.damoa.interaction.domain.InteractionHistory;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface InteractionHistoryRepository extends JpaRepository<InteractionHistory, Long> {

--- a/src/main/java/com/tenten/damoa/interactionhistory/domain/InteractionCategory.java
+++ b/src/main/java/com/tenten/damoa/interactionhistory/domain/InteractionCategory.java
@@ -1,6 +1,6 @@
 package com.tenten.damoa.interactionhistory.domain;
 
-public enum Category {
+public enum InteractionCategory {
     VIEW,
     LIKE,
     SHARE

--- a/src/main/java/com/tenten/damoa/interactionhistory/domain/InteractionHistory.java
+++ b/src/main/java/com/tenten/damoa/interactionhistory/domain/InteractionHistory.java
@@ -22,9 +22,9 @@ public class InteractionHistory {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false)
+    @Column(name = "category", nullable = false)
     @Enumerated(value = EnumType.STRING)
-    private Category category;
+    private InteractionCategory category;
 
     @Column(nullable = false)
     private LocalDateTime createdAt;

--- a/src/main/java/com/tenten/damoa/verification/domain/VerificationCode.java
+++ b/src/main/java/com/tenten/damoa/verification/domain/VerificationCode.java
@@ -1,4 +1,4 @@
-package com.tenten.damoa.verificationcode.domain;
+package com.tenten.damoa.verification.domain;
 
 import com.tenten.damoa.member.domain.Member;
 import jakarta.persistence.Column;

--- a/src/main/java/com/tenten/damoa/verification/repository/VerificationCodeRepository.java
+++ b/src/main/java/com/tenten/damoa/verification/repository/VerificationCodeRepository.java
@@ -1,6 +1,6 @@
-package com.tenten.damoa.verificationcode.repository;
+package com.tenten.damoa.verification.repository;
 
-import com.tenten.damoa.verificationcode.domain.VerificationCode;
+import com.tenten.damoa.verification.domain.VerificationCode;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface VerificationCodeRepository extends JpaRepository<VerificationCode, Long> {


### PR DESCRIPTION
## 🔥 구현 기능
> 일부 도메인 패키지와 클래스 이름을 재정의하였습니다.

## 🔥 구현 방법
도메인은 `소프트웨어 시스템이 해결하려고 하는 특정 문제 영역 또는 비즈니스 영역`을 의미한다고 합니다.

기존의 테이블 이름과 같은 `interactionhistory`나 `verificationcode`와 같은 패키지 이름도 좋지만, 이후에 상호작용과 사용자 검증에 대한 확장성을 고려한다면 테이블 이름보다는 어떤 문제 영역인지 포괄적으로 나타낼 수 있는 이름이면 좋을 것 같다고 생각하여 `interaction`과 `verification`으로 패키지명을 바꾸는걸 건의드립니다.

위 의견에 대해서 어떻게 생각하시나요? 이전 네이밍으로 진행해도 괜찮고, 다른 의견을 주셔도 좋을 것 같습니다!

하지만 본격적인 api 개발 전에 반영되어야 하는 부분이라 빠른 논의를 부탁드립니다!
    
## 🔥 참고 할만한 자료(선택)
https://happycloud-lee.tistory.com/94

저도 위의 자료를 다 읽어보진 않았는데, 초반 부분이 잘 정리되어 있는 것 같아 공유합니다!