### PR TITLE
[feat] 게시물 목록 API

### DIFF
--- a/src/main/java/com/tenten/damoa/post/controller/PostController.java
+++ b/src/main/java/com/tenten/damoa/post/controller/PostController.java
@@ -18,7 +18,7 @@ public class PostController {
     @GetMapping("/posts")
     public Page<PostQueryRes> getPosts(@RequestParam(required = false) String tag,
                                        @RequestParam(required = false) String type,
-                                       @RequestParam(name = "order-by", required = false, defaultValue = "created_at") String order_by,
+                                       @RequestParam(name = "order-by", required = false, defaultValue = "createdAt") String order_by,
                                        @RequestParam(required = false, defaultValue = "desc") String order,
                                        @RequestParam(name = "search-by", required = false, defaultValue = "title,content") String search_by,
                                        @RequestParam(required = false) String search,

--- a/src/main/java/com/tenten/damoa/post/controller/PostController.java
+++ b/src/main/java/com/tenten/damoa/post/controller/PostController.java
@@ -1,0 +1,31 @@
+package com.tenten.damoa.post.controller;
+
+import com.tenten.damoa.post.dto.PostQueryRes;
+import com.tenten.damoa.post.service.PostQueryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1")
+public class PostController {
+    private final PostQueryService postQueryService;
+
+    @GetMapping("/posts")
+    public Page<PostQueryRes> getPosts(@RequestParam(required = false) String tag,
+                                       @RequestParam(required = false) String type,
+                                       @RequestParam(name = "order-by", required = false, defaultValue = "created_at") String order_by,
+                                       @RequestParam(required = false, defaultValue = "desc") String order,
+                                       @RequestParam(name = "search-by", required = false, defaultValue = "title,content") String search_by,
+                                       @RequestParam(required = false) String search,
+                                       @RequestParam(name = "page-count", required = false, defaultValue = "10") int page_count,
+                                       @RequestParam(required = false, defaultValue = "0") int page) {
+
+        return postQueryService.getPosts(tag, type, order_by, order, search_by, search, page_count, page);
+    }
+
+}

--- a/src/main/java/com/tenten/damoa/post/controller/PostController.java
+++ b/src/main/java/com/tenten/damoa/post/controller/PostController.java
@@ -2,6 +2,8 @@ package com.tenten.damoa.post.controller;
 
 import com.tenten.damoa.post.dto.PostQueryRes;
 import com.tenten.damoa.post.service.PostQueryService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -16,6 +18,8 @@ public class PostController {
     private final PostQueryService postQueryService;
 
     @GetMapping("/posts")
+    @Tag(name = "post", description = "게시글 API")
+    @Operation(summary = "게시물 목록 조회 API", description = "쿼리 파라미터에 따라 조건에 맞는 게시물을 반환합니다.")
     public Page<PostQueryRes> getPosts(@RequestParam(required = false) String tag,
                                        @RequestParam(required = false) String type,
                                        @RequestParam(name = "order-by", required = false, defaultValue = "createdAt") String order_by,

--- a/src/main/java/com/tenten/damoa/post/domain/Post.java
+++ b/src/main/java/com/tenten/damoa/post/domain/Post.java
@@ -1,14 +1,12 @@
 package com.tenten.damoa.post.domain;
 
 import com.tenten.damoa.common.model.BaseEntity;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
+import com.tenten.damoa.hashtag.domain.Hashtag;
+import jakarta.persistence.*;
 import lombok.Getter;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -39,4 +37,7 @@ public class Post extends BaseEntity {
 
     @Column(nullable = false)
     private int shareCount;
+
+    @OneToMany(mappedBy = "post", fetch = FetchType.LAZY)
+    private List<Hashtag> hashtags = new ArrayList<>();
 }

--- a/src/main/java/com/tenten/damoa/post/dto/PostQueryRes.java
+++ b/src/main/java/com/tenten/damoa/post/dto/PostQueryRes.java
@@ -1,0 +1,30 @@
+package com.tenten.damoa.post.dto;
+
+import com.tenten.damoa.post.domain.Post;
+import com.tenten.damoa.post.domain.SnsType;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class PostQueryRes {
+    private Long id;
+    private String contentId;
+    private SnsType type;
+    private String title;
+    private String content;
+    private int viewCount;
+    private int likeCount;
+    private int shareCount;
+
+    public PostQueryRes(Post post) {
+        this.id = post.getId();
+        this.contentId = post.getContentId();
+        this.type = post.getType();
+        this.title = post.getTitle();
+        this.content = post.getContent();
+        this.viewCount = post.getViewCount();
+        this.likeCount = post.getLikeCount();
+        this.shareCount = post.getShareCount();
+    }
+}

--- a/src/main/java/com/tenten/damoa/post/dto/PostQueryRes.java
+++ b/src/main/java/com/tenten/damoa/post/dto/PostQueryRes.java
@@ -22,9 +22,16 @@ public class PostQueryRes {
         this.contentId = post.getContentId();
         this.type = post.getType();
         this.title = post.getTitle();
-        this.content = post.getContent();
         this.viewCount = post.getViewCount();
         this.likeCount = post.getLikeCount();
         this.shareCount = post.getShareCount();
+
+        // content 20자 제한
+        String content = post.getContent();
+        if (content.length() > 20) {
+            this.content = content.substring(0, 20);
+        } else {
+            this.content = content;
+        }
     }
 }

--- a/src/main/java/com/tenten/damoa/post/repository/PostRepository.java
+++ b/src/main/java/com/tenten/damoa/post/repository/PostRepository.java
@@ -1,8 +1,11 @@
 package com.tenten.damoa.post.repository;
 
 import com.tenten.damoa.post.domain.Post;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 
-public interface PostRepository extends JpaRepository<Post, Long> {
-
+public interface PostRepository extends JpaRepository<Post, Long>, JpaSpecificationExecutor<Post> {
 }

--- a/src/main/java/com/tenten/damoa/post/service/PostQueryService.java
+++ b/src/main/java/com/tenten/damoa/post/service/PostQueryService.java
@@ -1,0 +1,54 @@
+package com.tenten.damoa.post.service;
+
+import com.tenten.damoa.post.domain.Post;
+import com.tenten.damoa.post.dto.PostQueryRes;
+import com.tenten.damoa.post.repository.PostRepository;
+import com.tenten.damoa.post.specification.PostSpecification;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class PostQueryService {
+    private final PostRepository postRepository;
+
+    public Page<PostQueryRes> getPosts(String tag, String type, String order_by, String order, String search_by, String search, int page_count, int page) {
+
+        Sort.Direction direction = "asc".equalsIgnoreCase(order) ? Sort.Direction.ASC : Sort.Direction.DESC;
+        Pageable paging = PageRequest.of(page, page_count, Sort.by(direction, order_by));
+        Specification<Post> spec = (root, query, criteriaBuilder) -> null;
+
+        if (tag != null && !tag.isBlank()) {
+            spec = spec.and(PostSpecification.findByHashtag(tag));
+        } else {    // 로그인된 사용자 정보를 가져와야 하지만, Spring Security가 아직 없으므로 하드코딩
+            spec = spec.and(PostSpecification.findByHashtag("tenten"));
+        }
+        if (type != null && !type.isBlank()) {
+            spec = spec.and(PostSpecification.findByType(type));
+        }
+        if (search != null && !search.isBlank()) {
+            if(search_by.equals("title")) {
+                spec = spec.and(PostSpecification.findByTitle(search));
+            }
+            else if (search_by.equals("content")) {
+                spec = spec.and(PostSpecification.findByContent(search));
+            }
+            else {
+                spec = spec.and(PostSpecification.findByTitleOrContent(search));
+            }
+        }
+
+        Page<Post> postsPages = postRepository.findAll(spec, paging);
+
+        Page<PostQueryRes> getPostsRes = postsPages.map(
+                postPage -> new PostQueryRes(postPage)
+        );
+
+        return getPostsRes;
+    }
+}

--- a/src/main/java/com/tenten/damoa/post/specification/PostSpecification.java
+++ b/src/main/java/com/tenten/damoa/post/specification/PostSpecification.java
@@ -1,0 +1,30 @@
+package com.tenten.damoa.post.specification;
+
+import com.tenten.damoa.hashtag.domain.Hashtag;
+import com.tenten.damoa.post.domain.Post;
+import jakarta.persistence.criteria.Join;
+import org.springframework.data.jpa.domain.Specification;
+
+public class PostSpecification {
+    public static Specification<Post> findByHashtag(String tag) {
+        return (root, query, criteriaBuilder) -> {
+            Join<Post, Hashtag> hashtags = root.join("hashtags");
+            return criteriaBuilder.equal(hashtags.get("tag"), tag);
+        };
+    }
+    public static Specification<Post> findByType(String type) {
+        return (root, query, criteriaBuilder) -> criteriaBuilder.equal(root.get("type").as(String.class), type.toUpperCase());
+    }
+    public static Specification<Post> findByTitle(String search) {
+        return (root, query, criteriaBuilder) -> criteriaBuilder.like(root.get("title"), "%" + search + "%");
+    }
+    public static Specification<Post> findByContent(String search) {
+        return (root, query, criteriaBuilder) -> criteriaBuilder.like(root.get("content"), "%" + search + "%");
+    }
+    public static Specification<Post> findByTitleOrContent(String search) {
+        return (root, query, criteriaBuilder) -> criteriaBuilder.or(
+                criteriaBuilder.like(root.get("title"), "%" + search + "%"),
+                criteriaBuilder.like(root.get("content"), "%" + search + "%")
+        );
+    }
+}


### PR DESCRIPTION
## 🔥 구현 기능
> 쿼리 파라미터를 통해 hashtag, type, order_by, order(추가), search_by, page_count, page 값을 받아 쿼리 결과를 반환합니다.

## 🔥 구현 방법
1. @QueryParam을 통해 쿼리 파라미터를 가져옵니다.
2. `hashtag`가 null이라면 사용자 계정의 해시태그로 게시물을 조회하고, `hashtag`가 null이 아니라면 해당 해시태그로 게시물을 조회합니다. (다만 로그인된 사용자 정보를 가져오기 위해 Spring Security로 구현해야 하는데, 우선 하드코딩 처리)
3.  `type`이 null이 아니라면 해당 타입의 SNS 게시물을 조회합니다.
4. `order by`는 정렬 기준, `order`는 오름차순/내림차순입니다. 기준에 따라 정렬합니다.
5. `page_count`, `page`에 따라 페이징 처리합니다.

> QueryDSL을 사용하고자 했으나 설정상의 문제로 Specification 활용
> @QueryParam 대신 @ModelAttribute를 활용하고자 했으나 defalt value 처리가 불편하고, URI의 쿼리 파라미터 key 이름을 지정할 수 없다는 문제가 있었음

## 🔥 관련 이슈
related: #16
    
## 참고 할만한 자료(선택)
https://www.notion.so/sebel/d5fdab44824c4a62b0b8ed3ca83507ca?p=6720d2d3126942f1bbb6b95be8b9dcef&pm=s