### PR TITLE
[feat] 회원가입 API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,11 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'org.springframework.security:spring-security-test'
+
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/tenten/damoa/common/config/SecurityConfig.java
+++ b/src/main/java/com/tenten/damoa/common/config/SecurityConfig.java
@@ -1,0 +1,36 @@
+package com.tenten.damoa.common.config;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    @Bean
+    public BCryptPasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        return http.csrf(AbstractHttpConfigurer::disable)
+            .authorizeHttpRequests(authorizeHttpRequests ->
+                authorizeHttpRequests.anyRequest().permitAll()
+            ).build();
+    }
+
+    @Bean
+    @ConditionalOnProperty(name = "spring.h2.console.enabled", havingValue = "true")
+    public WebSecurityCustomizer configureH2ConsoleEnable() {
+        return web -> web.ignoring().requestMatchers(PathRequest.toH2Console());
+    }
+}

--- a/src/main/java/com/tenten/damoa/common/exception/ErrorCode.java
+++ b/src/main/java/com/tenten/damoa/common/exception/ErrorCode.java
@@ -18,6 +18,11 @@ public enum ErrorCode {
     MISSING_PARAMETER_EXCEPTION(HttpStatus.BAD_REQUEST, "필수 요청 값이 누락되었거나 잘못되었습니다."),
 
     /**
+     * 409 - Conflict
+     */
+    ACCOUNT_CONFLICT(HttpStatus.CONFLICT, "이미 사용중인 계정입니다."),
+
+    /**
      * 500 - Internal Server Error
      */
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 에러가 발생했습니다.")

--- a/src/main/java/com/tenten/damoa/common/util/RandomCodeUtil.java
+++ b/src/main/java/com/tenten/damoa/common/util/RandomCodeUtil.java
@@ -1,0 +1,22 @@
+package com.tenten.damoa.common.util;
+
+import java.util.Random;
+
+public class RandomCodeUtil {
+
+    private static final int LENGTH = 6;
+    private static final int ORIGIN = 48;
+    private static final int BOUND = 122;
+
+    public static String getRandomCode() {
+        Random random = new Random();
+        StringBuilder stringBuilder = new StringBuilder();
+
+        random.ints(ORIGIN, BOUND + 1)
+            .filter(i -> (i <= 57 || i >= 65) && (i <= 90 || i >= 97))
+            .limit(LENGTH)
+            .forEach(stringBuilder::appendCodePoint);
+
+        return stringBuilder.toString();
+    }
+}

--- a/src/main/java/com/tenten/damoa/common/util/RegexPatternUtil.java
+++ b/src/main/java/com/tenten/damoa/common/util/RegexPatternUtil.java
@@ -1,0 +1,6 @@
+package com.tenten.damoa.common.util;
+
+public class RegexPatternUtil {
+
+    public static final String PASSWORD = "^(?!.*(.)\\1\\1)(?=.*[A-Za-z].*[\\d!@#$%^&*]|.*[\\d!@#$%^&*].*[A-Za-z])[A-Za-z\\d!@#$%^&*]{10,}$";
+}

--- a/src/main/java/com/tenten/damoa/member/controller/MemberController.java
+++ b/src/main/java/com/tenten/damoa/member/controller/MemberController.java
@@ -1,0 +1,49 @@
+package com.tenten.damoa.member.controller;
+
+import static org.springframework.http.HttpStatus.CREATED;
+
+import com.tenten.damoa.common.exception.ErrorResponse;
+import com.tenten.damoa.member.controller.request.RegisterMemberReq;
+import com.tenten.damoa.member.controller.response.RegisterMemberRes;
+import com.tenten.damoa.member.service.MemberRegisterService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Validated
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/members")
+@Tag(name = "Member", description = "사용자 API")
+public class MemberController {
+
+    private final MemberRegisterService memberRegisterService;
+
+    @PostMapping("/register")
+    @Operation(summary = "사용자 회원가입")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "201", description = "사용자 회원가입 성공"),
+        @ApiResponse(
+            responseCode = "409",
+            description = "이미 사용중인 계정입니다.",
+            content = {@Content(schema = @Schema(implementation = ErrorResponse.class))}
+        )
+    })
+    public ResponseEntity<RegisterMemberRes> register(
+        @RequestBody @Valid RegisterMemberReq request
+    ) {
+        RegisterMemberRes response = memberRegisterService.execute(request);
+        return ResponseEntity.status(CREATED).body(response);
+    }
+}

--- a/src/main/java/com/tenten/damoa/member/controller/request/RegisterMemberReq.java
+++ b/src/main/java/com/tenten/damoa/member/controller/request/RegisterMemberReq.java
@@ -1,0 +1,43 @@
+package com.tenten.damoa.member.controller.request;
+
+import com.tenten.damoa.common.util.RegexPatternUtil;
+import com.tenten.damoa.member.domain.Member;
+import com.tenten.damoa.member.domain.MemberRole;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import java.time.LocalDateTime;
+import lombok.Getter;
+
+@Schema(description = "사용자 회원가입 요청 객체")
+@Getter
+public class RegisterMemberReq {
+
+    @Schema(description = "계정", example = "tenten")
+    @NotBlank(message = "계정은 필수 입력입니다.")
+    @Size(min = 1, max = 50, message = "계정은 1~50자만 가능합니다.")
+    private String account;
+
+    @Schema(description = "이메일", example = "tenten@gmail.com")
+    @NotBlank(message = "이메일은 필수 입력입니다.")
+    @Email(message = "올바른 이메일 형식을 입력해 주세요.")
+    @Size(min = 1, max = 100, message = "이메일은 1~100자만 가능합니다.")
+    private String email;
+
+    @Schema(description = "비밀번호", example = "password12!")
+    @NotBlank(message = "비밀번호는 필수 입력입니다.")
+    @Pattern(regexp = RegexPatternUtil.PASSWORD, message = "비밀번호는 1) 최소 10자 이상, 2) 숫자/문자/특수문자(!@#$%^&*) 중 2가지 이상 포함, 3) 3회 이상 연속되는 문자를 사용할 수 없습니다.")
+    private String password;
+
+    public Member toMember(String encryptedPassword) {
+        return Member.builder()
+            .account(account)
+            .email(email)
+            .password(encryptedPassword)
+            .role(MemberRole.PRE_MEMBER)
+            .joinedAt(LocalDateTime.now())
+            .build();
+    }
+}

--- a/src/main/java/com/tenten/damoa/member/controller/request/RegisterMemberReq.java
+++ b/src/main/java/com/tenten/damoa/member/controller/request/RegisterMemberReq.java
@@ -9,10 +9,12 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import java.time.LocalDateTime;
+import lombok.Builder;
 import lombok.Getter;
 
 @Schema(description = "사용자 회원가입 요청 객체")
 @Getter
+@Builder
 public class RegisterMemberReq {
 
     @Schema(description = "계정", example = "tenten")

--- a/src/main/java/com/tenten/damoa/member/controller/response/RegisterMemberRes.java
+++ b/src/main/java/com/tenten/damoa/member/controller/response/RegisterMemberRes.java
@@ -1,0 +1,21 @@
+package com.tenten.damoa.member.controller.response;
+
+import com.tenten.damoa.member.domain.Member;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Schema(description = "사용자 회원가입 응답 객체")
+@Getter
+@Builder
+public class RegisterMemberRes {
+
+    @Schema(description = "사용자 id", example = "uuid")
+    private String memberId;
+
+    public static RegisterMemberRes of(Member member) {
+        return RegisterMemberRes.builder()
+            .memberId(member.getId())
+            .build();
+    }
+}

--- a/src/main/java/com/tenten/damoa/member/domain/Member.java
+++ b/src/main/java/com/tenten/damoa/member/domain/Member.java
@@ -8,10 +8,14 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Member {
 
     @Id
@@ -33,4 +37,15 @@ public class Member {
 
     @Column(nullable = false)
     private LocalDateTime joinedAt;
+
+    @Builder
+    public Member(
+        String account, String email, String password, MemberRole role, LocalDateTime joinedAt
+    ) {
+        this.account = account;
+        this.email = email;
+        this.password = password;
+        this.role = role;
+        this.joinedAt = joinedAt;
+    }
 }

--- a/src/main/java/com/tenten/damoa/member/repository/MemberRepository.java
+++ b/src/main/java/com/tenten/damoa/member/repository/MemberRepository.java
@@ -5,4 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
+    Boolean existsByAccount(String account);
 }

--- a/src/main/java/com/tenten/damoa/member/service/MemberRegisterService.java
+++ b/src/main/java/com/tenten/damoa/member/service/MemberRegisterService.java
@@ -1,0 +1,43 @@
+package com.tenten.damoa.member.service;
+
+import static com.tenten.damoa.common.exception.ErrorCode.ACCOUNT_CONFLICT;
+
+import com.tenten.damoa.common.exception.BusinessException;
+import com.tenten.damoa.member.controller.request.RegisterMemberReq;
+import com.tenten.damoa.member.controller.response.RegisterMemberRes;
+import com.tenten.damoa.member.domain.Member;
+import com.tenten.damoa.member.repository.MemberRepository;
+import com.tenten.damoa.verification.domain.VerificationCode;
+import com.tenten.damoa.verification.repository.VerificationCodeRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class MemberRegisterService {
+
+    private final MemberRepository memberRepository;
+    private final VerificationCodeRepository verificationCodeRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @Transactional
+    public RegisterMemberRes execute(RegisterMemberReq request) {
+        verifyAccount(request.getAccount());
+
+        Member member = request.toMember(passwordEncoder.encode(request.getPassword()));
+        memberRepository.save(member);
+
+        VerificationCode verificationCode = VerificationCode.create(member);
+        verificationCodeRepository.save(verificationCode);
+
+        return RegisterMemberRes.of(member);
+    }
+
+    private void verifyAccount(String account) {
+        if (memberRepository.existsByAccount(account)) {
+            throw new BusinessException(ACCOUNT_CONFLICT);
+        }
+    }
+}

--- a/src/main/java/com/tenten/damoa/verification/domain/VerificationCode.java
+++ b/src/main/java/com/tenten/damoa/verification/domain/VerificationCode.java
@@ -1,5 +1,6 @@
 package com.tenten.damoa.verification.domain;
 
+import com.tenten.damoa.common.util.RandomCodeUtil;
 import com.tenten.damoa.member.domain.Member;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -10,10 +11,14 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class VerificationCode {
 
     @Id
@@ -29,4 +34,19 @@ public class VerificationCode {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
+
+    @Builder
+    public VerificationCode(String code, LocalDateTime sendAt, Member member) {
+        this.code = code;
+        this.sendAt = sendAt;
+        this.member = member;
+    }
+
+    public static VerificationCode create(Member member) {
+        return VerificationCode.builder()
+            .code(RandomCodeUtil.getRandomCode())
+            .sendAt(LocalDateTime.now())
+            .member(member)
+            .build();
+    }
 }

--- a/src/test/java/com/tenten/damoa/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/tenten/damoa/member/controller/MemberControllerTest.java
@@ -1,0 +1,112 @@
+package com.tenten.damoa.member.controller;
+
+import static com.tenten.damoa.common.exception.ErrorCode.ACCOUNT_CONFLICT;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.setup.MockMvcBuilders.standaloneSetup;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.tenten.damoa.common.exception.BusinessException;
+import com.tenten.damoa.common.exception.GlobalExceptionHandler;
+import com.tenten.damoa.member.controller.request.RegisterMemberReq;
+import com.tenten.damoa.member.controller.response.RegisterMemberRes;
+import com.tenten.damoa.member.domain.Member;
+import com.tenten.damoa.member.domain.MemberRole;
+import com.tenten.damoa.member.service.MemberRegisterService;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+@ExtendWith(MockitoExtension.class)
+class MemberControllerTest {
+
+    @Mock
+    private MemberRegisterService memberRegisterService;
+
+    @InjectMocks
+    private MemberController memberController;
+
+    private MockMvc mockMvc;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = standaloneSetup(memberController)
+            .setControllerAdvice(GlobalExceptionHandler.class)
+            .alwaysDo(print())
+            .build();
+    }
+
+    @DisplayName("사용자가 회원가입을 성공하면 201을 반환한다.")
+    @Test
+    public void memberRegisterSuccessReturn201() throws Exception {
+        // given
+        RegisterMemberReq request = getRegisterMemberReq();
+        Member member = getMember();
+        RegisterMemberRes response = RegisterMemberRes.of(member);
+
+        when(memberRegisterService.execute(any())).thenReturn(response);
+
+        // when
+        ResultActions resultActions = mockMvc.perform(
+            post("/api/v1/members/register")
+                .contentType(APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request))
+        );
+
+        // then
+        resultActions.andExpect(status().isCreated())
+            .andExpect(jsonPath("$.memberId").value(response.getMemberId()));
+    }
+
+    @DisplayName("사용자가 이미 사용중인 계정으로 회원가입을 하면 409를 반환한다.")
+    @Test
+    void memberAccountConflictRegisterReturn404() throws Exception {
+        // given
+        RegisterMemberReq request = getRegisterMemberReq();
+
+        when(memberRegisterService.execute(any()))
+            .thenThrow(new BusinessException(ACCOUNT_CONFLICT));
+
+        // when
+        ResultActions resultActions = mockMvc.perform(
+            post("/api/v1/members/register")
+                .contentType(APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request))
+        );
+
+        // then
+        resultActions.andExpect(status().isConflict())
+            .andExpect(jsonPath("$.message").value("이미 사용중인 계정입니다."));
+    }
+
+    private RegisterMemberReq getRegisterMemberReq() {
+        return RegisterMemberReq.builder()
+            .account("tenten")
+            .email("tenten@gmail.com")
+            .password("password12!")
+            .build();
+    }
+
+    private Member getMember() {
+        return Member.builder()
+            .account("tenten")
+            .email("tenten@gmail.com")
+            .password("password12!")
+            .role(MemberRole.PRE_MEMBER)
+            .joinedAt(LocalDateTime.now())
+            .build();
+    }
+}

--- a/src/test/java/com/tenten/damoa/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/tenten/damoa/member/controller/MemberControllerTest.java
@@ -73,7 +73,7 @@ class MemberControllerTest {
 
     @DisplayName("사용자가 이미 사용중인 계정으로 회원가입을 하면 409를 반환한다.")
     @Test
-    void memberAccountConflictRegisterReturn404() throws Exception {
+    void memberAccountConflictRegisterReturn409() throws Exception {
         // given
         RegisterMemberReq request = getRegisterMemberReq();
 

--- a/src/test/java/com/tenten/damoa/member/service/MemberRegisterServiceTest.java
+++ b/src/test/java/com/tenten/damoa/member/service/MemberRegisterServiceTest.java
@@ -1,0 +1,83 @@
+package com.tenten.damoa.member.service;
+
+import static com.tenten.damoa.common.exception.ErrorCode.ACCOUNT_CONFLICT;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import com.tenten.damoa.common.exception.BusinessException;
+import com.tenten.damoa.member.controller.request.RegisterMemberReq;
+import com.tenten.damoa.member.controller.response.RegisterMemberRes;
+import com.tenten.damoa.member.domain.Member;
+import com.tenten.damoa.member.repository.MemberRepository;
+import com.tenten.damoa.verification.domain.VerificationCode;
+import com.tenten.damoa.verification.repository.VerificationCodeRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@ExtendWith(MockitoExtension.class)
+class MemberRegisterServiceTest {
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private VerificationCodeRepository verificationCodeRepository;
+
+    @Spy
+    private PasswordEncoder passwordEncoder;
+
+    @InjectMocks
+    private MemberRegisterService memberRegisterService;
+
+    @DisplayName("사용자가 회원가입을 하면 사용자 회원가입 응답 객체를 반환한다.")
+    @Test
+    void memberRegisterReturnRegisterMemberRes() {
+        // given
+        RegisterMemberReq request = getRegisterMemberReq();
+        Member member = request.toMember(passwordEncoder.encode(request.getPassword()));
+        VerificationCode verificationCode = VerificationCode.create(member);
+
+        when(memberRepository.existsByAccount(any())).thenReturn(false);
+        when(memberRepository.save(any())).thenReturn(member);
+        when(verificationCodeRepository.save(any())).thenReturn(verificationCode);
+
+        // when
+        RegisterMemberRes result = memberRegisterService.execute(request);
+
+        // then
+        assertThat(result.getMemberId()).isEqualTo(member.getId());
+    }
+
+    @DisplayName("사용자가 이미 사용중인 계정으로 회원가입을 하면 예외가 발생한다.")
+    @Test
+    void memberAccountConflictRegisterThrowsException() {
+        // given
+        RegisterMemberReq request = getRegisterMemberReq();
+
+        when(memberRepository.existsByAccount(any())).thenReturn(true);
+
+        // when
+        BusinessException exception = assertThrows(BusinessException.class,
+            () -> memberRegisterService.execute(request)
+        );
+
+        // then
+        assertThat(exception.getErrorCode()).isEqualTo(ACCOUNT_CONFLICT);
+    }
+
+    private RegisterMemberReq getRegisterMemberReq() {
+        return RegisterMemberReq.builder()
+            .account("tenten")
+            .email("tenten@gmail.com")
+            .password("password12!")
+            .build();
+    }
+}


### PR DESCRIPTION
## 🔥 구현 기능
> 계정, 이메일, 비밀번호를 request로 받아 member, verificationcode에 저장하는 사용자 회원가입 API를 구현하였습니다.

## 🔥 구현 방법
- request에서 validation을 이용하여 계정, 이메일, 비밀번호를 검증하였습니다.
  - 비밀번호 정규표현식을 구현하여 제약조건도 적용하였습니다.
- 계정이 이미 DB에 존재하는지 확인하여, 있으면 '이미 사용중인 계정입니다.' 라는 409 Conflict 에러를 발생시켰습니다.
- 비밀번호 암호화는 스프링 시큐리티 BCryptPasswordEncoder를 사용하여 구현하였습니다.
- 인증코드는 아스키코드 표를 참고하여 숫자(0-9), 문자(A-Z, a-z)로 구성된 6자리 랜덤 코드를 생성하도록 구현하였습니다.
- 회원가입이 완료되면 201 상태코드 + member id가 반환되도록 하였습니다.
- 컨트롤러, 서비스 테스트 코드도 작성하였습니다.

## 🔥 관련 이슈
related: #17 
    
## 참고 할만한 자료(선택)
