### PR TITLE
[feat] 로그인 API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,11 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'org.springframework.security:spring-security-test'
+
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
@@ -40,6 +44,11 @@ dependencies {
 
 	// API Docs
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
+
+	// JWT
+	implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/tenten/damoa/common/config/OpenApiConfig.java
+++ b/src/main/java/com/tenten/damoa/common/config/OpenApiConfig.java
@@ -1,18 +1,30 @@
 package com.tenten.damoa.common.config;
 
+import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityScheme;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class OpenApiConfig {
 
+    public static final String ACCESS_TOKEN_KEY = "Access Token";
+
     @Bean
     public OpenAPI customOpenAPI() {
+        SecurityScheme accessTokenSecurityScheme = new SecurityScheme()
+            .type(SecurityScheme.Type.HTTP)
+            .scheme("Bearer")
+            .bearerFormat("JWT")
+            .name("Authorization");
+        Components components = new Components()
+            .addSecuritySchemes(ACCESS_TOKEN_KEY, accessTokenSecurityScheme);
+
         return new OpenAPI()
-                .info(new Info()
-                        .title("Damoa Server API Docs"));
+            .info(new Info().title("Damoa Server API Docs"))
+            .components(components);
     }
 }
 

--- a/src/main/java/com/tenten/damoa/common/config/SecurityConfig.java
+++ b/src/main/java/com/tenten/damoa/common/config/SecurityConfig.java
@@ -1,0 +1,36 @@
+package com.tenten.damoa.common.config;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    @Bean
+    public BCryptPasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        return http.csrf(AbstractHttpConfigurer::disable)
+            .authorizeHttpRequests(authorizeHttpRequests ->
+                authorizeHttpRequests.anyRequest().permitAll()
+            ).build();
+    }
+
+    @Bean
+    @ConditionalOnProperty(name = "spring.h2.console.enabled", havingValue = "true")
+    public WebSecurityCustomizer configureH2ConsoleEnable() {
+        return web -> web.ignoring().requestMatchers(PathRequest.toH2Console());
+    }
+}

--- a/src/main/java/com/tenten/damoa/common/config/WebMvcConfig.java
+++ b/src/main/java/com/tenten/damoa/common/config/WebMvcConfig.java
@@ -1,0 +1,19 @@
+package com.tenten.damoa.common.config;
+
+import com.tenten.damoa.common.config.auth.JwtInterceptor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebMvcConfig implements WebMvcConfigurer {
+
+    private final JwtInterceptor jwtInterceptor;
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(jwtInterceptor);
+    }
+}

--- a/src/main/java/com/tenten/damoa/common/config/auth/Auth.java
+++ b/src/main/java/com/tenten/damoa/common/config/auth/Auth.java
@@ -1,0 +1,14 @@
+package com.tenten.damoa.common.config.auth;
+
+import com.tenten.damoa.member.domain.MemberRole;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Auth {
+
+    MemberRole role() default MemberRole.PRE_MEMBER;
+}

--- a/src/main/java/com/tenten/damoa/common/config/auth/Auth.java
+++ b/src/main/java/com/tenten/damoa/common/config/auth/Auth.java
@@ -10,5 +10,5 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 public @interface Auth {
 
-    MemberRole role() default MemberRole.PRE_MEMBER;
+    MemberRole role() default MemberRole.MEMBER;
 }

--- a/src/main/java/com/tenten/damoa/common/config/auth/JwtInterceptor.java
+++ b/src/main/java/com/tenten/damoa/common/config/auth/JwtInterceptor.java
@@ -1,0 +1,50 @@
+package com.tenten.damoa.common.config.auth;
+
+import static com.tenten.damoa.common.exception.ErrorCode.*;
+
+import com.tenten.damoa.common.exception.BusinessException;
+import com.tenten.damoa.member.domain.MemberRole;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.method.HandlerMethod;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+@Component
+@RequiredArgsConstructor
+public class JwtInterceptor implements HandlerInterceptor {
+
+    private final JwtUtil jwtUtil;
+
+    @Override
+    public boolean preHandle(
+        HttpServletRequest request,
+        HttpServletResponse response,
+        Object handler
+    ) throws Exception {
+        String bearerToken = request.getHeader("Authorization");
+
+        if (handler instanceof HandlerMethod handlerMethod) {
+            Auth auth = handlerMethod.getMethodAnnotation(Auth.class);
+            if (auth != null) {
+                if (bearerToken == null) {
+                    throw new BusinessException(LOGIN_UNAUTHORIZED);
+                }
+
+                String token = bearerToken.substring(7);
+                if (!jwtUtil.verifyToken(token)) {
+                    throw new BusinessException(INVALID_TOKEN_UNAUTHORIZED);
+                }
+
+                MemberRole role = MemberRole.valueOf(jwtUtil.getMemberRole(token));
+                if (!role.equals(auth.role())) {
+                    throw new BusinessException(PRE_MEMBER_FORBIDDEN);
+                }
+
+                request.setAttribute("account", jwtUtil.getMemberAccount(token));
+            }
+        }
+        return true;
+    }
+}

--- a/src/main/java/com/tenten/damoa/common/config/auth/JwtToken.java
+++ b/src/main/java/com/tenten/damoa/common/config/auth/JwtToken.java
@@ -1,0 +1,13 @@
+package com.tenten.damoa.common.config.auth;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class JwtToken {
+
+    private String grantType;
+    private String accessToken;
+    private String refreshToken;
+}

--- a/src/main/java/com/tenten/damoa/common/config/auth/JwtUtil.java
+++ b/src/main/java/com/tenten/damoa/common/config/auth/JwtUtil.java
@@ -1,0 +1,99 @@
+package com.tenten.damoa.common.config.auth;
+
+import com.tenten.damoa.member.domain.Member;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.UnsupportedJwtException;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import io.jsonwebtoken.security.SecurityException;
+import java.security.Key;
+import java.time.Instant;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import javax.crypto.SecretKey;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class JwtUtil {
+
+    private final Key key;
+    private final long accessTokenExpTime;
+    private final long refreshTokenExpTime;
+
+    public JwtUtil(
+        @Value("${jwt.secret}") String secretKey,
+        @Value("${jwt.time.access}") long accessTokenExpTime,
+        @Value("${jwt.time.refresh}") long refreshTokenExpTime
+    ) {
+        byte[] keyBytes = Decoders.BASE64.decode(secretKey);
+        this.key = Keys.hmacShaKeyFor(keyBytes);
+        this.accessTokenExpTime = accessTokenExpTime;
+        this.refreshTokenExpTime = refreshTokenExpTime;
+    }
+
+    public JwtToken createToken(Member member) {
+        Map<String, Object> claims = new HashMap<>();
+        claims.put("account", member.getAccount());
+        claims.put("role", member.getRole());
+
+        Instant now = Instant.now();
+
+        String accessToken = Jwts.builder()
+            .subject(member.getAccount())
+            .claims(claims)
+            .issuedAt(Date.from(now))
+            .expiration(Date.from(now.plusSeconds(accessTokenExpTime)))
+            .signWith(key)
+            .compact();
+
+        String refreshToken = Jwts.builder()
+            .expiration(Date.from(now.plusSeconds(refreshTokenExpTime)))
+            .signWith(key)
+            .compact();
+
+        return JwtToken.builder()
+            .grantType("Bearer")
+            .accessToken(accessToken)
+            .refreshToken(refreshToken)
+            .build();
+    }
+
+    public boolean verifyToken(String token) {
+        try {
+            parseClaims(token);
+            return true;
+        } catch (SecurityException | MalformedJwtException e) {
+            log.info("Invalid JWT Token", e);
+        } catch (ExpiredJwtException e) {
+            log.info("Expired JWT Token", e);
+        } catch (UnsupportedJwtException e) {
+            log.info("Unsupported JWT Token", e);
+        } catch (IllegalArgumentException e) {
+            log.info("JWT claims string is empty", e);
+        }
+        return false;
+    }
+
+    public String getMemberAccount(String token) {
+        return parseClaims(token).get("account", String.class);
+    }
+
+    public String getMemberRole(String token) {
+        return parseClaims(token).get("role", String.class);
+    }
+
+    public Claims parseClaims(String token) {
+        return Jwts.parser()
+            .verifyWith((SecretKey) key)
+            .build()
+            .parseSignedClaims(token)
+            .getPayload();
+    }
+}

--- a/src/main/java/com/tenten/damoa/common/exception/ErrorCode.java
+++ b/src/main/java/com/tenten/damoa/common/exception/ErrorCode.java
@@ -18,6 +18,19 @@ public enum ErrorCode {
     MISSING_PARAMETER_EXCEPTION(HttpStatus.BAD_REQUEST, "필수 요청 값이 누락되었거나 잘못되었습니다."),
 
     /**
+     * 401 - Unauthorized
+     */
+    ACCOUNT_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "존재하지 않는 계정입니다."),
+    PASSWORD_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "비밀번호를 잘못 입력했습니다."),
+    LOGIN_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "로그인을 먼저 해주세요."),
+    INVALID_TOKEN_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다."),
+
+    /**
+     * 403 - Forbidden
+     */
+    PRE_MEMBER_FORBIDDEN(HttpStatus.FORBIDDEN, "서비스 회원이 아닙니다. 이메일 인증을 먼저 해주세요."),
+
+    /**
      * 500 - Internal Server Error
      */
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 에러가 발생했습니다.")

--- a/src/main/java/com/tenten/damoa/member/controller/MemberController.java
+++ b/src/main/java/com/tenten/damoa/member/controller/MemberController.java
@@ -1,0 +1,50 @@
+package com.tenten.damoa.member.controller;
+
+import com.tenten.damoa.common.exception.ErrorResponse;
+import com.tenten.damoa.member.controller.request.LoginMemberReq;
+import com.tenten.damoa.member.controller.response.LoginMemberRes;
+import com.tenten.damoa.member.service.MemberLoginService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Validated
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/members")
+@Tag(name = "Member", description = "사용자 API")
+public class MemberController {
+
+    private final MemberLoginService memberLoginService;
+
+    @PostMapping("/login")
+    @Operation(summary = "사용자 로그인")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "사용자 로그인 성공"),
+        @ApiResponse(
+            responseCode = "401",
+            description = "1. 존재하지 않는 계정입니다.\n2. 비밀번호를 잘못 입력했습니다.",
+            content = {@Content(schema = @Schema(implementation = ErrorResponse.class))}
+        ),
+        @ApiResponse(
+            responseCode = "403",
+            description = "서비스 회원이 아닙니다. 이메일 인증을 먼저 해주세요.",
+            content = {@Content(schema = @Schema(implementation = ErrorResponse.class))}
+        )
+    })
+    public ResponseEntity<LoginMemberRes> login(@RequestBody @Valid LoginMemberReq request) {
+        LoginMemberRes response = memberLoginService.execute(request);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/tenten/damoa/member/controller/request/LoginMemberReq.java
+++ b/src/main/java/com/tenten/damoa/member/controller/request/LoginMemberReq.java
@@ -2,10 +2,12 @@ package com.tenten.damoa.member.controller.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
 import lombok.Getter;
 
 @Schema(description = "사용자 로그인 요청 객체")
 @Getter
+@Builder
 public class LoginMemberReq {
 
     @Schema(description = "계정", example = "tenten")

--- a/src/main/java/com/tenten/damoa/member/controller/request/LoginMemberReq.java
+++ b/src/main/java/com/tenten/damoa/member/controller/request/LoginMemberReq.java
@@ -1,0 +1,18 @@
+package com.tenten.damoa.member.controller.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Schema(description = "사용자 로그인 요청 객체")
+@Getter
+public class LoginMemberReq {
+
+    @Schema(description = "계정", example = "tenten")
+    @NotBlank(message = "계정은 필수 입력입니다.")
+    private String account;
+
+    @Schema(description = "비밀번호", example = "password12!")
+    @NotBlank(message = "비밀번호는 필수 입력입니다.")
+    private String password;
+}

--- a/src/main/java/com/tenten/damoa/member/controller/response/LoginMemberRes.java
+++ b/src/main/java/com/tenten/damoa/member/controller/response/LoginMemberRes.java
@@ -1,0 +1,30 @@
+package com.tenten.damoa.member.controller.response;
+
+import com.tenten.damoa.common.config.auth.JwtToken;
+import com.tenten.damoa.member.domain.Member;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Schema(description = "사용자 로그인 응답 객체")
+@Getter
+@Builder
+public class LoginMemberRes {
+
+    @Schema(description = "사용자 계정", example = "tenten")
+    private String account;
+
+    @Schema(description = "액세스 토큰")
+    private String accessToken;
+
+    @Schema(description = "리프레시 토큰")
+    private String refreshToken;
+
+    public static LoginMemberRes of(Member member, JwtToken token) {
+        return LoginMemberRes.builder()
+            .account(member.getAccount())
+            .accessToken(token.getAccessToken())
+            .refreshToken(token.getRefreshToken())
+            .build();
+    }
+}

--- a/src/main/java/com/tenten/damoa/member/domain/Member.java
+++ b/src/main/java/com/tenten/damoa/member/domain/Member.java
@@ -11,10 +11,14 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Member {
 
     @Id
@@ -36,6 +40,17 @@ public class Member {
 
     @Column(nullable = false)
     private LocalDateTime joinedAt;
+
+    @Builder
+    public Member(
+        String account, String email, String password, MemberRole role, LocalDateTime joinedAt
+    ) {
+        this.account = account;
+        this.email = email;
+        this.password = password;
+        this.role = role;
+        this.joinedAt = joinedAt;
+    }
 
     public void verifyMemberRole() {
         if (role == MemberRole.PRE_MEMBER) {

--- a/src/main/java/com/tenten/damoa/member/domain/Member.java
+++ b/src/main/java/com/tenten/damoa/member/domain/Member.java
@@ -1,5 +1,8 @@
 package com.tenten.damoa.member.domain;
 
+import static com.tenten.damoa.common.exception.ErrorCode.PRE_MEMBER_FORBIDDEN;
+
+import com.tenten.damoa.common.exception.BusinessException;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -33,4 +36,10 @@ public class Member {
 
     @Column(nullable = false)
     private LocalDateTime joinedAt;
+
+    public void verifyMemberRole() {
+        if (role == MemberRole.PRE_MEMBER) {
+            throw new BusinessException(PRE_MEMBER_FORBIDDEN);
+        }
+    }
 }

--- a/src/main/java/com/tenten/damoa/member/repository/MemberRepository.java
+++ b/src/main/java/com/tenten/damoa/member/repository/MemberRepository.java
@@ -1,8 +1,10 @@
 package com.tenten.damoa.member.repository;
 
 import com.tenten.damoa.member.domain.Member;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
+    Optional<Member> findByAccount(String account);
 }

--- a/src/main/java/com/tenten/damoa/member/service/MemberLoginService.java
+++ b/src/main/java/com/tenten/damoa/member/service/MemberLoginService.java
@@ -1,0 +1,50 @@
+package com.tenten.damoa.member.service;
+
+import static com.tenten.damoa.common.exception.ErrorCode.ACCOUNT_UNAUTHORIZED;
+import static com.tenten.damoa.common.exception.ErrorCode.PASSWORD_UNAUTHORIZED;
+
+import com.tenten.damoa.common.config.auth.JwtToken;
+import com.tenten.damoa.common.config.auth.JwtUtil;
+import com.tenten.damoa.common.exception.BusinessException;
+import com.tenten.damoa.member.controller.request.LoginMemberReq;
+import com.tenten.damoa.member.controller.response.LoginMemberRes;
+import com.tenten.damoa.member.domain.Member;
+import com.tenten.damoa.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class MemberLoginService {
+
+    private final MemberRepository memberRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final JwtUtil jwtUtil;
+
+    @Transactional
+    public LoginMemberRes execute(LoginMemberReq request) {
+        Member member = findMember(request);
+        member.verifyMemberRole();
+
+        JwtToken token = jwtUtil.createToken(member);
+
+        return LoginMemberRes.of(member, token);
+    }
+
+    private Member findMember(LoginMemberReq request) {
+        Member member = memberRepository
+            .findByAccount(request.getAccount())
+            .orElseThrow(() -> new BusinessException(ACCOUNT_UNAUTHORIZED));
+        verifyPassword(request.getPassword(), member.getPassword());
+
+        return member;
+    }
+
+    private void verifyPassword(String rawPassword, String encodedPassword) {
+        if (!passwordEncoder.matches(rawPassword, encodedPassword)) {
+            throw new BusinessException(PASSWORD_UNAUTHORIZED);
+        }
+    }
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -13,6 +13,3 @@ spring:
   sql:
     init:
       mode: always
-
-jwt:
-  secret: ${JWT_SECRET}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,3 +10,9 @@ spring:
         show_sql: true
         format_sql: true
     open-in-view: false
+
+jwt:
+  secret: ${JWT_SECRET}
+  time:
+    access: ${JWT_ACCESS}
+    refresh: ${JWT_REFRESH}

--- a/src/test/java/com/tenten/damoa/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/tenten/damoa/member/controller/MemberControllerTest.java
@@ -1,0 +1,161 @@
+package com.tenten.damoa.member.controller;
+
+import static com.tenten.damoa.common.exception.ErrorCode.ACCOUNT_UNAUTHORIZED;
+import static com.tenten.damoa.common.exception.ErrorCode.PASSWORD_UNAUTHORIZED;
+import static com.tenten.damoa.common.exception.ErrorCode.PRE_MEMBER_FORBIDDEN;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.setup.MockMvcBuilders.standaloneSetup;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.tenten.damoa.common.config.auth.JwtToken;
+import com.tenten.damoa.common.exception.BusinessException;
+import com.tenten.damoa.common.exception.GlobalExceptionHandler;
+import com.tenten.damoa.member.controller.request.LoginMemberReq;
+import com.tenten.damoa.member.controller.response.LoginMemberRes;
+import com.tenten.damoa.member.domain.Member;
+import com.tenten.damoa.member.domain.MemberRole;
+import com.tenten.damoa.member.service.MemberLoginService;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+@ExtendWith(MockitoExtension.class)
+class MemberControllerTest {
+
+    @Mock
+    private MemberLoginService memberLoginService;
+
+    @InjectMocks
+    private MemberController memberController;
+
+    private MockMvc mockMvc;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = standaloneSetup(memberController)
+            .setControllerAdvice(GlobalExceptionHandler.class)
+            .alwaysDo(print())
+            .build();
+    }
+
+    @DisplayName("사용자가 로그인을 성공하면 200을 반환한다.")
+    @Test
+    public void memberLoginSuccessReturn200() throws Exception {
+        // given
+        LoginMemberReq request = getLoginMemberReq();
+        LoginMemberRes response = LoginMemberRes.of(getMember(), JwtToken.builder().build());
+
+        when(memberLoginService.execute(any())).thenReturn(response);
+
+        // when
+        ResultActions resultActions = mockMvc.perform(
+            post("/api/v1/members/login")
+                .contentType(APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request))
+        );
+
+        // then
+        resultActions.andExpect(status().isOk())
+            .andExpect(jsonPath("$.account").value(response.getAccount()))
+            .andExpect(jsonPath("$.accessToken").value(response.getAccessToken()))
+            .andExpect(jsonPath("$.refreshToken").value(response.getRefreshToken()));
+    }
+
+    @DisplayName("사용자가 존재하지 않는 계정으로 로그인을 하면 401을 반환한다.")
+    @Test
+    void memberAccountUnauthorizedLoginReturn401() throws Exception {
+        // given
+        LoginMemberReq request = getLoginMemberReq();
+
+        when(memberLoginService.execute(any())).thenThrow(
+            new BusinessException(ACCOUNT_UNAUTHORIZED)
+        );
+
+        // when
+        ResultActions resultActions = mockMvc.perform(
+            post("/api/v1/members/login")
+                .contentType(APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request))
+        );
+
+        // then
+        resultActions.andExpect(status().isUnauthorized())
+            .andExpect(jsonPath("$.message").value("존재하지 않는 계정입니다."));
+    }
+
+    @DisplayName("사용자가 비밀번호 잘못 입력 후 로그인을 하면 401을 반환한다.")
+    @Test
+    void memberPasswordUnauthorizedLoginReturn401() throws Exception {
+        // given
+        LoginMemberReq request = getLoginMemberReq();
+
+        when(memberLoginService.execute(any())).thenThrow(
+            new BusinessException(PASSWORD_UNAUTHORIZED)
+        );
+
+        // when
+        ResultActions resultActions = mockMvc.perform(
+            post("/api/v1/members/login")
+                .contentType(APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request))
+        );
+
+        // then
+        resultActions.andExpect(status().isUnauthorized())
+            .andExpect(jsonPath("$.message").value("비밀번호를 잘못 입력했습니다."));
+    }
+
+    @DisplayName("이메일 인증을 하지 않은 사용자가 로그인을 하면 403을 반환한다.")
+    @Test
+    void preMemberForbiddenLoginReturn403() throws Exception {
+        // given
+        LoginMemberReq request = getLoginMemberReq();
+
+        when(memberLoginService.execute(any())).thenThrow(
+            new BusinessException(PRE_MEMBER_FORBIDDEN)
+        );
+
+        // when
+        ResultActions resultActions = mockMvc.perform(
+            post("/api/v1/members/login")
+                .contentType(APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request))
+        );
+
+        // then
+        resultActions.andExpect(status().isForbidden())
+            .andExpect(jsonPath("$.message").value("서비스 회원이 아닙니다. 이메일 인증을 먼저 해주세요."));
+    }
+
+
+    private LoginMemberReq getLoginMemberReq() {
+        return LoginMemberReq.builder()
+            .account("tenten")
+            .password("password12!")
+            .build();
+    }
+
+    private Member getMember() {
+        return Member.builder()
+            .account("tenten")
+            .email("tenten@gmail.com")
+            .password("password12!")
+            .role(MemberRole.PRE_MEMBER)
+            .joinedAt(LocalDateTime.now())
+            .build();
+    }
+}

--- a/src/test/java/com/tenten/damoa/member/service/MemberLoginServiceTest.java
+++ b/src/test/java/com/tenten/damoa/member/service/MemberLoginServiceTest.java
@@ -1,0 +1,147 @@
+package com.tenten.damoa.member.service;
+
+import static com.tenten.damoa.common.exception.ErrorCode.ACCOUNT_UNAUTHORIZED;
+import static com.tenten.damoa.common.exception.ErrorCode.PASSWORD_UNAUTHORIZED;
+import static com.tenten.damoa.common.exception.ErrorCode.PRE_MEMBER_FORBIDDEN;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import com.tenten.damoa.common.config.auth.JwtToken;
+import com.tenten.damoa.common.config.auth.JwtUtil;
+import com.tenten.damoa.common.exception.BusinessException;
+import com.tenten.damoa.member.controller.request.LoginMemberReq;
+import com.tenten.damoa.member.controller.response.LoginMemberRes;
+import com.tenten.damoa.member.domain.Member;
+import com.tenten.damoa.member.domain.MemberRole;
+import com.tenten.damoa.member.repository.MemberRepository;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@ExtendWith(MockitoExtension.class)
+class MemberLoginServiceTest {
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Spy
+    private PasswordEncoder passwordEncoder;
+
+    @Mock
+    private JwtUtil jwtUtil;
+
+    @InjectMocks
+    private MemberLoginService memberLoginService;
+
+    @DisplayName("사용자가 로그인을 하면 사용자 로그인 응답 객체를 반환한다.")
+    @Test
+    void memberLoginReturnLoginMemberRes() {
+        // given
+        LoginMemberReq request = getLoginMemberReq();
+        Member member = getMember();
+
+        when(memberRepository.findByAccount(any())).thenReturn(Optional.ofNullable(member));
+        when(passwordEncoder.matches(any(), any())).thenReturn(true);
+        when(jwtUtil.createToken(any())).thenReturn(
+            JwtToken.builder()
+                .accessToken("accessToken")
+                .refreshToken("refreshToken")
+                .build()
+        );
+
+        // when
+        LoginMemberRes result = memberLoginService.execute(request);
+
+        // then
+        assertThat(result.getAccount()).isEqualTo(member != null ? member.getAccount() : null);
+    }
+
+    @DisplayName("사용자가 존재하지 않는 계정으로 로그인을 하면 예외가 발생한다.")
+    @Test
+    void memberAccountUnauthorizedLoginThrowsException() {
+        // given
+        LoginMemberReq request = getLoginMemberReq();
+
+        when(memberRepository.findByAccount(any())).thenReturn(Optional.empty());
+
+        // when
+        BusinessException exception = assertThrows(BusinessException.class,
+            () -> memberLoginService.execute(request)
+        );
+
+        // then
+        assertThat(exception.getErrorCode()).isEqualTo(ACCOUNT_UNAUTHORIZED);
+    }
+
+    @DisplayName("사용자가 비밀번호 잘못 입력 후 로그인을 하면 예외가 발생한다.")
+    @Test
+    void memberPasswordUnauthorizedLoginThrowsException() {
+        // given
+        LoginMemberReq request = getLoginMemberReq();
+
+        when(memberRepository.findByAccount(any())).thenReturn(Optional.ofNullable(getMember()));
+        when(passwordEncoder.matches(any(), any())).thenReturn(false);
+
+        // when
+        BusinessException exception = assertThrows(BusinessException.class,
+            () -> memberLoginService.execute(request)
+        );
+
+        // then
+        assertThat(exception.getErrorCode()).isEqualTo(PASSWORD_UNAUTHORIZED);
+    }
+
+    @DisplayName("이메일 인증을 하지 않은 사용자가 로그인을 하면 예외가 발생한다.")
+    @Test
+    void preMemberForbiddenLoginThrowsException() {
+        // given
+        LoginMemberReq request = getLoginMemberReq();
+
+        when(memberRepository.findByAccount(any())).thenReturn(Optional.ofNullable(getPreMember()));
+        when(passwordEncoder.matches(any(), any())).thenReturn(true);
+
+        // when
+        BusinessException exception = assertThrows(BusinessException.class,
+            () -> memberLoginService.execute(request)
+        );
+
+        // then
+        assertThat(exception.getErrorCode()).isEqualTo(PRE_MEMBER_FORBIDDEN);
+    }
+
+    private LoginMemberReq getLoginMemberReq() {
+        return LoginMemberReq.builder()
+            .account("tenten")
+            .password("password12!")
+            .build();
+    }
+
+    private Member getMember() {
+        return Member.builder()
+            .account("tenten")
+            .email("tenten@gmail.com")
+            .password("password12!")
+            .role(MemberRole.MEMBER)
+            .joinedAt(LocalDateTime.now())
+            .build();
+    }
+
+    private Member getPreMember() {
+        return Member.builder()
+            .account("tenten2")
+            .email("tenten2@gmail.com")
+            .password("password12!")
+            .role(MemberRole.PRE_MEMBER)
+            .joinedAt(LocalDateTime.now())
+            .build();
+    }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,0 +1,14 @@
+spring:
+  config:
+    import: application-secret.properties
+  datasource:
+    url: jdbc:h2:mem:test;MODE=MYSQL
+    username: sa
+    password:
+    driver-class-name: org.h2.Driver
+
+jwt:
+  secret: ${JWT_SECRET}
+  time:
+    access: ${JWT_ACCESS}
+    refresh: ${JWT_REFRESH}


### PR DESCRIPTION
## 🔥 구현 기능
> 계정, 비밀번호를 request로 받아 jwt를 생성, 검증하는 사용자 로그인 API를 구현하였습니다.

## 🔥 구현 방법
- 계정, 비밀번호가 DB에 저장된 정보와 일치하는지 확인하여, 없으면 '존재하지 않는 계정입니다.', '비밀번호를 잘못 입력했습니다.' 라는 401 Unauthorized 에러를 발생시켰습니다.
- 사용자의 role이 PRE_MEMBER(가입 승인이 되지 않은 경우), '서비스 회원이 아닙니다. 이메일 인증을 먼저 해주세요.' 라는 403 Forbidden 에러를 발생시켰습니다.
- JwtUtil 클래스에서 jwt 생성, 검증을 구현하였습니다.
- 인터셉터를 통해 request 헤더 검증을 구현하였습니다.
  - 헤더에 access token이 없을 경우
  - 유효하지 않은 토큰인 경우
  - 서비스 회원이 아닌 경우(PRE_MEMBER)
- 로그인이 완료되면 200 상태코드 + 계정, access token, refresh token 이 반환되도록 하였습니다.
- 컨트롤러, 서비스 테스트 코드도 작성하였습니다.

## 🔥 관련 이슈
related: #18 
    
## 참고 할만한 자료(선택)
- 회원가입 부분이 머지가 되어야 테스트하기 편리하실 것 같아서, 지금은 코드만 봐주셔도 될 것 같습니다,,!

- 스웨거에서 Authorize 버튼을 눌러 access token을 입력하고,
<img width="645" alt="image" src="https://github.com/user-attachments/assets/0bad0ea3-2175-4ca4-913b-32e5825392b5">

- controller 부분에서 Auth 어노테이션을 사용하고, security 설정을 하면, 헤더에 access token이 포함됩니다.
<img width="745" alt="image" src="https://github.com/user-attachments/assets/90df8b96-50a3-40b6-a34b-ec9328382dfd">

- 헤더에 access token이 필요한 API(게시물, 통계 쪽)에서 위의 순서대로 적용하시면 될 것 같습니다.

- [노션](https://www.notion.so/sebel/aa0a5abbe1a34d2e962c2a4e71b78cdd)에 jwt 관련 env 적어두었습니다.