### PR TITLE
[feat] 해시태그별 통계 조회 API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,12 @@ dependencies {
 
 	// API Docs
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
+
+	// queryDSL
+	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+	annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
+	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 }
 
 tasks.named('test') {

--- a/src/main/java/com/tenten/damoa/common/config/QueryDslConfig.java
+++ b/src/main/java/com/tenten/damoa/common/config/QueryDslConfig.java
@@ -1,0 +1,19 @@
+package com.tenten.damoa.common.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@RequiredArgsConstructor
+public class QueryDslConfig {
+
+    private final EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/main/java/com/tenten/damoa/common/exception/ErrorCode.java
+++ b/src/main/java/com/tenten/damoa/common/exception/ErrorCode.java
@@ -1,5 +1,8 @@
 package com.tenten.damoa.common.exception;
 
+import static com.tenten.damoa.stat.domain.Period.MAX_DATE_BASED_DATE;
+import static com.tenten.damoa.stat.domain.Period.MAX_DATE_BASED_HOUR;
+
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -16,6 +19,13 @@ public enum ErrorCode {
     METHOD_ARGUMENT_VALIDATION_FAILED(HttpStatus.BAD_REQUEST, "입력된 값이 유효하지 않습니다. 각 파라미터의 조건을 확인해 주세요."),
     INVALID_FORMAT_EXCEPTION(HttpStatus.BAD_REQUEST, "요청된 데이터의 형식이 잘못되었습니다. 유효한 JSON 형식을 사용해 주세요."),
     MISSING_PARAMETER_EXCEPTION(HttpStatus.BAD_REQUEST, "필수 요청 값이 누락되었거나 잘못되었습니다."),
+
+    INVALID_TIME_UNIT_EXCEPTION(HttpStatus.BAD_REQUEST, "입력된 시간 단위가 유효하지 않습니다."),
+    INVALID_METRICS_TYPE_EXCEPTION(HttpStatus.BAD_REQUEST, "입력된 지표 종류가 유효하지 않습니다."),
+
+    INVALID_PERIOD_EXCEPTION(HttpStatus.BAD_REQUEST, "입력된 기간의 종료일이 시작일보다 빠릅니다."),
+    PERIOD_HOUR_LIMIT_EXCEED_EXCEPTION(HttpStatus.BAD_REQUEST, String.format("시간단위 조회 기간의 제한범위를 초과했습니다. (%d일)", MAX_DATE_BASED_HOUR)),
+    PERIOD_DATE_LIMIT_EXCEED_EXCEPTION(HttpStatus.BAD_REQUEST, String.format("날짜단위 조회 기간의 제한범위를 초과했습니다. (%d일)", MAX_DATE_BASED_DATE)),
 
     /**
      * 500 - Internal Server Error

--- a/src/main/java/com/tenten/damoa/stat/controller/StatController.java
+++ b/src/main/java/com/tenten/damoa/stat/controller/StatController.java
@@ -1,8 +1,20 @@
 package com.tenten.damoa.stat.controller;
 
+import static com.tenten.damoa.stat.domain.Period.MAX_DATE_BASED_DATE;
+import static com.tenten.damoa.stat.domain.Period.MAX_DATE_BASED_HOUR;
+
+import com.tenten.damoa.common.exception.ErrorResponse;
 import com.tenten.damoa.stat.controller.dto.HashtagStatRes;
 import com.tenten.damoa.stat.service.HashtagStatQueryService;
 import com.tenten.damoa.stat.service.command.HashtagStatCommand;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import java.time.LocalDateTime;
@@ -14,6 +26,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "통계")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/")
@@ -21,12 +34,36 @@ public class StatController {
 
     private final HashtagStatQueryService hashtagStatQueryService;
 
+    @Operation(summary = "해시태그별 통계")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "조회 성공",
+                    content = @Content(
+                            array = @ArraySchema(
+                                    schema = @Schema(implementation = HashtagStatRes.class)
+                            ))
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "입력된 시간 단위가 유효하지 않거나, " +
+                            "입력된 지표 종류가 유효하지 않거나, " +
+                            "입력된 기간의 종료일이 시작일보다 빠르거나, " +
+                            "시간단위 조회 기간의 제한범위를 초과했거나, " +
+                            "날짜단위 조회 기간의 제한범위를 초과했습니다.",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
     @GetMapping("/hashtags/stat")
     public ResponseEntity<List<HashtagStatRes>> getHashTagMetricsStat(
+            @Parameter(description = "검색어", example = "tenten")
             @RequestParam @NotBlank String hashtag,
+            @Parameter(description = "시간단위 `HOUR`/`DATE`", example = "DATE")
             @RequestParam @NotBlank String unit,
+            @Parameter(description = "지표 `COUNT`/`VIEW_COUNT`/`LIKE_COUNT`/`SHARE_COUNT`", example = "VIEW_COUNT")
             @RequestParam @NotBlank String metric,
+            @Parameter(description = "시작일", example = "2024-08-01T00:00:00")
             @RequestParam @NotNull LocalDateTime start,
+            @Parameter(description = "종료일", example = "2024-08-31T23:59:59")
             @RequestParam @NotNull LocalDateTime end
     ) {
         HashtagStatCommand command = HashtagStatCommand.builder()

--- a/src/main/java/com/tenten/damoa/stat/controller/StatController.java
+++ b/src/main/java/com/tenten/damoa/stat/controller/StatController.java
@@ -1,0 +1,44 @@
+package com.tenten.damoa.stat.controller;
+
+import com.tenten.damoa.stat.controller.dto.HashtagStatRes;
+import com.tenten.damoa.stat.service.HashtagStatQueryService;
+import com.tenten.damoa.stat.service.command.HashtagStatCommand;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/")
+public class StatController {
+
+    private final HashtagStatQueryService hashtagStatQueryService;
+
+    @GetMapping("/hashtags/stat")
+    public ResponseEntity<List<HashtagStatRes>> getHashTagMetricsStat(
+            @RequestParam @NotBlank String hashtag,
+            @RequestParam @NotBlank String unit,
+            @RequestParam @NotBlank String metric,
+            @RequestParam @NotNull LocalDateTime start,
+            @RequestParam @NotNull LocalDateTime end
+    ) {
+        HashtagStatCommand command = HashtagStatCommand.builder()
+                .hashtag(hashtag)
+                .unit(unit)
+                .metric(metric)
+                .start(start)
+                .end(end)
+                .build();
+
+        List<HashtagStatRes> response = hashtagStatQueryService.getStatsForPeriod(command);
+
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/tenten/damoa/stat/controller/StatController.java
+++ b/src/main/java/com/tenten/damoa/stat/controller/StatController.java
@@ -1,8 +1,5 @@
 package com.tenten.damoa.stat.controller;
 
-import static com.tenten.damoa.stat.domain.Period.MAX_DATE_BASED_DATE;
-import static com.tenten.damoa.stat.domain.Period.MAX_DATE_BASED_HOUR;
-
 import com.tenten.damoa.common.exception.ErrorResponse;
 import com.tenten.damoa.stat.controller.dto.HashtagStatRes;
 import com.tenten.damoa.stat.service.HashtagStatQueryService;

--- a/src/main/java/com/tenten/damoa/stat/controller/dto/HashtagStatRes.java
+++ b/src/main/java/com/tenten/damoa/stat/controller/dto/HashtagStatRes.java
@@ -1,11 +1,16 @@
 package com.tenten.damoa.stat.controller.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 import lombok.Builder;
 
+@Schema(description = "해시태그 통계 응답 객체")
 @Builder
 public record HashtagStatRes(
+        @Schema(description = "일자")
         LocalDateTime date,
+
+        @Schema(description = "값")
         Integer value
 ) {
 }

--- a/src/main/java/com/tenten/damoa/stat/controller/dto/HashtagStatRes.java
+++ b/src/main/java/com/tenten/damoa/stat/controller/dto/HashtagStatRes.java
@@ -1,0 +1,11 @@
+package com.tenten.damoa.stat.controller.dto;
+
+import java.time.LocalDateTime;
+import lombok.Builder;
+
+@Builder
+public record HashtagStatRes(
+        LocalDateTime date,
+        Integer value
+) {
+}

--- a/src/main/java/com/tenten/damoa/stat/domain/MetricsType.java
+++ b/src/main/java/com/tenten/damoa/stat/domain/MetricsType.java
@@ -1,0 +1,20 @@
+package com.tenten.damoa.stat.domain;
+
+import com.tenten.damoa.common.exception.BusinessException;
+import com.tenten.damoa.common.exception.ErrorCode;
+
+public enum MetricsType {
+    COUNT,
+    VIEW_COUNT,
+    LIKE_COUNT,
+    SHARE_COUNT
+    ;
+
+    public static MetricsType from(String name) {
+        try {
+            return valueOf(name);
+        } catch (IllegalArgumentException e) {
+            throw new BusinessException(ErrorCode.INVALID_METRICS_TYPE_EXCEPTION);
+        }
+    }
+}

--- a/src/main/java/com/tenten/damoa/stat/domain/Period.java
+++ b/src/main/java/com/tenten/damoa/stat/domain/Period.java
@@ -1,0 +1,45 @@
+package com.tenten.damoa.stat.domain;
+
+import com.tenten.damoa.common.exception.BusinessException;
+import com.tenten.damoa.common.exception.ErrorCode;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class Period {
+
+    public static final int MAX_DATE_BASED_HOUR = 7;
+    public static final int MAX_DATE_BASED_DATE = 30;
+
+    private final  LocalDateTime start;
+    private final LocalDateTime end;
+
+    @Builder
+    private Period(TimeUnit unit, LocalDateTime start, LocalDateTime end) {
+        validate(unit, start, end);
+
+        this.start = start;
+        this.end = end;
+    }
+
+    private void validate(TimeUnit unit, LocalDateTime start, LocalDateTime end) {
+        if (start.isAfter(end)) {
+            throw new BusinessException(ErrorCode.INVALID_PERIOD_EXCEPTION);
+        }
+
+        switch (unit) {
+            case HOUR -> {
+                if (ChronoUnit.DAYS.between(start, end) > MAX_DATE_BASED_HOUR) {
+                    throw new BusinessException(ErrorCode.PERIOD_HOUR_LIMIT_EXCEED_EXCEPTION);
+                }
+            }
+            case DATE -> {
+                if (ChronoUnit.DAYS.between(start, end) > MAX_DATE_BASED_DATE) {
+                    throw new BusinessException(ErrorCode.PERIOD_DATE_LIMIT_EXCEED_EXCEPTION);
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/com/tenten/damoa/stat/domain/TimeUnit.java
+++ b/src/main/java/com/tenten/damoa/stat/domain/TimeUnit.java
@@ -1,0 +1,18 @@
+package com.tenten.damoa.stat.domain;
+
+import com.tenten.damoa.common.exception.BusinessException;
+import com.tenten.damoa.common.exception.ErrorCode;
+
+public enum TimeUnit {
+    DATE,
+    HOUR
+    ;
+
+    public static TimeUnit from(String name) {
+        try {
+            return valueOf(name);
+        } catch (IllegalArgumentException e) {
+            throw new BusinessException(ErrorCode.INVALID_TIME_UNIT_EXCEPTION);
+        }
+    }
+}

--- a/src/main/java/com/tenten/damoa/stat/repository/StatRepository.java
+++ b/src/main/java/com/tenten/damoa/stat/repository/StatRepository.java
@@ -1,0 +1,12 @@
+package com.tenten.damoa.stat.repository;
+
+import com.tenten.damoa.stat.controller.dto.HashtagStatRes;
+import com.tenten.damoa.stat.service.command.HashtagStatCommand;
+import java.util.List;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface StatRepository {
+
+    List<HashtagStatRes> getMetricsCount(HashtagStatCommand command);
+}

--- a/src/main/java/com/tenten/damoa/stat/repository/StatRepository.java
+++ b/src/main/java/com/tenten/damoa/stat/repository/StatRepository.java
@@ -8,5 +8,7 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface StatRepository {
 
-    List<HashtagStatRes> getMetricsCount(HashtagStatCommand command);
+    List<HashtagStatRes> getMetricsCountForPeriod(HashtagStatCommand command);
+
+    List<HashtagStatRes> getPostCountForPeriod(HashtagStatCommand command);
 }

--- a/src/main/java/com/tenten/damoa/stat/repository/StatRepositoryImpl.java
+++ b/src/main/java/com/tenten/damoa/stat/repository/StatRepositoryImpl.java
@@ -1,0 +1,86 @@
+package com.tenten.damoa.stat.repository;
+
+import static com.tenten.damoa.interaction.domain.QInteractionHistory.interactionHistory;
+import static com.tenten.damoa.hashtag.domain.QHashtag.hashtag;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.DateTemplate;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.tenten.damoa.common.exception.BusinessException;
+import com.tenten.damoa.common.exception.ErrorCode;
+import com.tenten.damoa.stat.controller.dto.HashtagStatRes;
+import com.tenten.damoa.interaction.domain.InteractionCategory;
+import com.tenten.damoa.stat.domain.MetricsType;
+import com.tenten.damoa.stat.domain.TimeUnit;
+import com.tenten.damoa.stat.service.command.HashtagStatCommand;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.Objects;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class StatRepositoryImpl implements StatRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<HashtagStatRes> getMetricsCount(HashtagStatCommand command) {
+        DateTemplate<String> date = getDateTemplateByTimeUnit(command.unit());
+
+        return queryFactory
+                .select(date, interactionHistory.count())
+                .from(interactionHistory)
+                .join(hashtag).on(interactionHistory.post.id.eq(hashtag.post.id))
+                .where(
+                        hashtagEq(command.hashtag()),
+                        categoryEq(command.metric()),
+                        interactionHistory.createdAt.goe(command.period().getStart()),
+                        interactionHistory.createdAt.loe(command.period().getEnd())
+                )
+                .groupBy(date)
+                .orderBy(date.asc())
+                .fetch()
+                .stream()
+                .filter(Objects::nonNull)
+                .map(tuple -> HashtagStatRes.builder()
+                        .date(LocalDateTime.parse(tuple.get(date), DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")))
+                        .value(Objects.requireNonNull(tuple.get(interactionHistory.count())).intValue())
+                        .build())
+                .toList();
+    }
+
+    private DateTemplate<String> getDateTemplateByTimeUnit(TimeUnit unit) {
+        switch (unit) {
+            case DATE -> {
+                return Expressions.dateTemplate(
+                        String.class,
+                        "DATE_FORMAT({0}, '%Y-%m-%d %00:00:00')",
+                        interactionHistory.createdAt);
+            }
+            case HOUR -> {
+                return Expressions.dateTemplate(
+                        String.class,
+                        "DATE_FORMAT({0}, '%Y-%m-%d %H:00:00')",
+                        interactionHistory.createdAt);
+            }
+            default -> throw new BusinessException(ErrorCode.BAD_REQUEST);
+        }
+    }
+
+    private BooleanExpression hashtagEq(String tag) {
+        return hashtag.tag.eq(tag);
+    }
+
+    private BooleanExpression categoryEq(MetricsType type) {
+        return switch (type) {
+            case VIEW_COUNT -> interactionHistory.category.eq(InteractionCategory.VIEW);
+            case LIKE_COUNT -> interactionHistory.category.eq(InteractionCategory.LIKE);
+            case SHARE_COUNT -> interactionHistory.category.eq(InteractionCategory.SHARE);
+            default -> throw new BusinessException(ErrorCode.BAD_REQUEST);
+        };
+    }
+}

--- a/src/main/java/com/tenten/damoa/stat/service/HashtagStatQueryService.java
+++ b/src/main/java/com/tenten/damoa/stat/service/HashtagStatQueryService.java
@@ -1,0 +1,24 @@
+package com.tenten.damoa.stat.service;
+
+import com.tenten.damoa.stat.controller.dto.HashtagStatRes;
+import com.tenten.damoa.stat.repository.StatRepository;
+import com.tenten.damoa.stat.service.command.HashtagStatCommand;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class HashtagStatQueryService {
+
+    private final StatRepository statRepository;
+
+    public List<HashtagStatRes> getStatsForPeriod(HashtagStatCommand command) {
+        return switch (command.metric()) {
+            case COUNT -> statRepository.getPostCountForPeriod(command);
+            default -> statRepository.getMetricsCountForPeriod(command);
+        };
+    }
+}

--- a/src/main/java/com/tenten/damoa/stat/service/command/HashtagStatCommand.java
+++ b/src/main/java/com/tenten/damoa/stat/service/command/HashtagStatCommand.java
@@ -1,0 +1,29 @@
+package com.tenten.damoa.stat.service.command;
+
+import com.tenten.damoa.stat.domain.MetricsType;
+import com.tenten.damoa.stat.domain.Period;
+import com.tenten.damoa.stat.domain.TimeUnit;
+import java.time.LocalDateTime;
+import lombok.Builder;
+
+public record HashtagStatCommand(
+        String hashtag,
+        TimeUnit unit,
+        Period period,
+        MetricsType metric
+) {
+
+    @Builder
+    public HashtagStatCommand(String hashtag, String unit, LocalDateTime start, LocalDateTime end, String metric) {
+        this(
+                hashtag,
+                TimeUnit.from(unit),
+                Period.builder()
+                        .unit(TimeUnit.from(unit))
+                        .start(start)
+                        .end(end)
+                        .build(),
+                MetricsType.from(metric)
+        );
+    }
+}


### PR DESCRIPTION
## 🔥 구현 기능
> 검색한 해시태그의 통계값(게시물 수, 좋아요 수, 공유 수, 조회수)를 시간별 / 날짜별로 조회하는 API를 구현했습니다.

## 🔥 구현 방법
- QueryDsl을 사용하여 날짜/시간별로 grouping하여 조회하는 동적 쿼리를 작성했습니다.
- TimeUnit, MetricsType 등의 Enum 클래스를 정의하여 동적 쿼리의 조건을 판단하도록 구현했습니다.

이후 로그인/회원가입 API가 병합된 후에 hashtag 검색어가 없는 경우 내 계정을 검색하도록 구현할 예정입니다.

## 🔥 관련 이슈
related: #22 
    
## 🔥 참고 할만한 자료
- API 요구사항 명세서
https://www.notion.so/sebel/cfd48229c4e8487ab96a5c1900bdda64?pvs=4