### PR TITLE
[fix] 게시물 상세 에러 해결

### DIFF
--- a/src/main/java/com/tenten/damoa/member/controller/MemberController.java
+++ b/src/main/java/com/tenten/damoa/member/controller/MemberController.java
@@ -56,7 +56,7 @@ public class MemberController {
 
     @Auth
     @PostMapping("/login")
-    @Operation(summary = "사용자 로그인", security = {@SecurityRequirement(name = ACCESS_TOKEN_KEY)})
+    @Operation(summary = "사용자 로그인")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "사용자 로그인 성공"),
         @ApiResponse(

--- a/src/main/java/com/tenten/damoa/member/controller/MemberController.java
+++ b/src/main/java/com/tenten/damoa/member/controller/MemberController.java
@@ -1,6 +1,6 @@
 package com.tenten.damoa.member.controller;
 
-import static com.tenten.damoa.common.config.OpenApiConfig.ACCESS_TOKEN_KEY;
+
 import static org.springframework.http.HttpStatus.CREATED;
 
 import com.tenten.damoa.common.config.auth.Auth;
@@ -16,7 +16,6 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
-import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -54,7 +53,6 @@ public class MemberController {
         return ResponseEntity.status(CREATED).body(response);
     }
 
-    @Auth
     @PostMapping("/login")
     @Operation(summary = "사용자 로그인")
     @ApiResponses(value = {

--- a/src/main/java/com/tenten/damoa/post/controller/PostController.java
+++ b/src/main/java/com/tenten/damoa/post/controller/PostController.java
@@ -40,13 +40,13 @@ public class PostController {
     @GetMapping("/posts")
     @Operation(summary = "게시물 목록 조회", description = "쿼리 파라미터에 따라 조건에 맞는 게시물을 반환합니다.")
     public ResponseEntity<Page<PostsQueryRes>> getPosts(@RequestParam(required = false) String tag,
-                                        @RequestParam(required = false) String type,
-                                        @RequestParam(name = "order-by", required = false, defaultValue = "createdAt") String orderBy,
-                                        @RequestParam(required = false, defaultValue = "desc") String order,
-                                        @RequestParam(name = "search-by", required = false, defaultValue = "title, content") String searchBy,
-                                        @RequestParam(required = false) String search,
-                                        @RequestParam(name = "page-size", required = false, defaultValue = "10") int pageSize,
-                                        @RequestParam(required = false, defaultValue = "0") int page) {
+        @RequestParam(required = false) String type,
+        @RequestParam(name = "order-by", required = false, defaultValue = "createdAt") String orderBy,
+        @RequestParam(required = false, defaultValue = "desc") String order,
+        @RequestParam(name = "search-by", required = false, defaultValue = "title, content") String searchBy,
+        @RequestParam(required = false) String search,
+        @RequestParam(name = "page-size", required = false, defaultValue = "10") int pageSize,
+        @RequestParam(required = false, defaultValue = "0") int page) {
 
         Page<PostsQueryRes> postQueryRes = postQueryService.getPosts(tag, type, orderBy, order, searchBy, search, pageSize, page);
         return ResponseEntity.ok(postQueryRes);

--- a/src/main/java/com/tenten/damoa/post/controller/PostController.java
+++ b/src/main/java/com/tenten/damoa/post/controller/PostController.java
@@ -1,4 +1,5 @@
 package com.tenten.damoa.post.controller;
+
 import com.tenten.damoa.post.dto.PostQueryRes;
 import com.tenten.damoa.post.service.PostShareService;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -39,29 +40,27 @@ public class PostController {
     @GetMapping("/posts")
     @Operation(summary = "게시물 목록 조회", description = "쿼리 파라미터에 따라 조건에 맞는 게시물을 반환합니다.")
     public ResponseEntity<Page<PostsQueryRes>> getPosts(@RequestParam(required = false) String tag,
-                                                        @RequestParam(required = false) String type,
-                                                        @RequestParam(name = "order-by", required = false, defaultValue = "createdAt") String orderBy,
-                                                        @RequestParam(required = false, defaultValue = "desc") String order,
-                                                        @RequestParam(name = "search-by", required = false, defaultValue = "title, content") String searchBy,
-                                                        @RequestParam(required = false) String search,
-                                                        @RequestParam(name = "page-size", required = false, defaultValue = "10") int pageSize,
-                                                        @RequestParam(required = false, defaultValue = "0") int page) {
+                                        @RequestParam(required = false) String type,
+                                        @RequestParam(name = "order-by", required = false, defaultValue = "createdAt") String orderBy,
+                                        @RequestParam(required = false, defaultValue = "desc") String order,
+                                        @RequestParam(name = "search-by", required = false, defaultValue = "title, content") String searchBy,
+                                        @RequestParam(required = false) String search,
+                                        @RequestParam(name = "page-size", required = false, defaultValue = "10") int pageSize,
+                                        @RequestParam(required = false, defaultValue = "0") int page) {
 
-        Page<PostsQueryRes> postQueryRes = postQueryService.getPosts(tag, type, orderBy, order, searchBy,
-                search, pageSize, page);
-
+        Page<PostsQueryRes> postQueryRes = postQueryService.getPosts(tag, type, orderBy, order, searchBy, search, pageSize, page);
         return ResponseEntity.ok(postQueryRes);
     }
 
     @PostMapping("/posts/{postId}")
     @Operation(
-        summary = "게시글 좋아요",
-        description = "지정된 ID의 게시글에 대해 좋아요를 처리합니다.",
-        responses = {
-            @ApiResponse(responseCode = "200", description = "좋아요 처리되었습니다."),
-            @ApiResponse(responseCode = "400", description = "게시글이 존재하지 않습니다."),
-            @ApiResponse(responseCode = "500", description = "서버 에러로 인해 처리 실패")
-        }
+            summary = "게시글 좋아요",
+            description = "지정된 ID의 게시글에 대해 좋아요를 처리합니다.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "좋아요 처리되었습니다."),
+                    @ApiResponse(responseCode = "400", description = "게시글이 존재하지 않습니다."),
+                    @ApiResponse(responseCode = "500", description = "서버 에러로 인해 처리 실패")
+            }
     )
     public ResponseEntity<String> postLike(@PathVariable Long postId) {
         postService.postLike(postId);

--- a/src/main/java/com/tenten/damoa/post/controller/PostController.java
+++ b/src/main/java/com/tenten/damoa/post/controller/PostController.java
@@ -32,8 +32,8 @@ public class PostController {
 
     @GetMapping("/posts/{postId}/detail")
     @Operation(summary = "게시물 상세 조회", description = "게시물 id를 통해 상세 조회하는 API")
-    public ResponseEntity<Post> getPostDetail(@PathVariable("postId") Long id) {
-        Post postDetail = postQueryService.getPostDetail(id);
+    public ResponseEntity<PostQueryRes> getPostDetail(@PathVariable("postId") Long id) {
+        PostQueryRes postDetail = postQueryService.getPostDetail(id);
 
         return ResponseEntity.ok(postDetail);
     }

--- a/src/main/java/com/tenten/damoa/post/controller/PostController.java
+++ b/src/main/java/com/tenten/damoa/post/controller/PostController.java
@@ -1,6 +1,5 @@
 package com.tenten.damoa.post.controller;
-import com.tenten.damoa.common.exception.BusinessException;
-import com.tenten.damoa.common.exception.ErrorCode;
+import com.tenten.damoa.post.dto.PostQueryRes;
 import com.tenten.damoa.post.service.PostShareService;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
@@ -12,8 +11,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import com.tenten.damoa.post.domain.Post;
-import com.tenten.damoa.post.dto.PostQueryRes;
+import com.tenten.damoa.post.dto.PostsQueryRes;
 import com.tenten.damoa.post.service.PostQueryService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -40,16 +38,16 @@ public class PostController {
 
     @GetMapping("/posts")
     @Operation(summary = "게시물 목록 조회", description = "쿼리 파라미터에 따라 조건에 맞는 게시물을 반환합니다.")
-    public ResponseEntity<Page<PostQueryRes>> getPosts(@RequestParam(required = false) String tag,
-            @RequestParam(required = false) String type,
-            @RequestParam(name = "order-by", required = false, defaultValue = "createdAt") String orderBy,
-            @RequestParam(required = false, defaultValue = "desc") String order,
-            @RequestParam(name = "search-by", required = false, defaultValue = "title, content") String searchBy,
-            @RequestParam(required = false) String search,
-            @RequestParam(name = "page-size", required = false, defaultValue = "10") int pageSize,
-            @RequestParam(required = false, defaultValue = "0") int page) {
+    public ResponseEntity<Page<PostsQueryRes>> getPosts(@RequestParam(required = false) String tag,
+                                                        @RequestParam(required = false) String type,
+                                                        @RequestParam(name = "order-by", required = false, defaultValue = "createdAt") String orderBy,
+                                                        @RequestParam(required = false, defaultValue = "desc") String order,
+                                                        @RequestParam(name = "search-by", required = false, defaultValue = "title, content") String searchBy,
+                                                        @RequestParam(required = false) String search,
+                                                        @RequestParam(name = "page-size", required = false, defaultValue = "10") int pageSize,
+                                                        @RequestParam(required = false, defaultValue = "0") int page) {
 
-        Page<PostQueryRes> postQueryRes = postQueryService.getPosts(tag, type, orderBy, order, searchBy,
+        Page<PostsQueryRes> postQueryRes = postQueryService.getPosts(tag, type, orderBy, order, searchBy,
                 search, pageSize, page);
 
         return ResponseEntity.ok(postQueryRes);

--- a/src/main/java/com/tenten/damoa/post/domain/Post.java
+++ b/src/main/java/com/tenten/damoa/post/domain/Post.java
@@ -1,13 +1,6 @@
 package com.tenten.damoa.post.domain;
 
 import com.tenten.damoa.common.model.BaseEntity;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;

--- a/src/main/java/com/tenten/damoa/post/dto/PostQueryRes.java
+++ b/src/main/java/com/tenten/damoa/post/dto/PostQueryRes.java
@@ -1,9 +1,13 @@
 package com.tenten.damoa.post.dto;
 
+import com.tenten.damoa.hashtag.domain.Hashtag;
 import com.tenten.damoa.post.domain.Post;
 import com.tenten.damoa.post.domain.SnsType;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Getter
 @NoArgsConstructor
@@ -16,6 +20,7 @@ public class PostQueryRes {
     private int viewCount;
     private int likeCount;
     private int shareCount;
+    private List<String> hashtags;
 
     public PostQueryRes(Post post) {
         this.id = post.getId();
@@ -26,5 +31,8 @@ public class PostQueryRes {
         this.likeCount = post.getLikeCount();
         this.shareCount = post.getShareCount();
         this.content = post.getContent();
+        this.hashtags = post.getHashtags().stream()
+                .map(Hashtag::getTag) // 해시태그 이름을 추출한다고 가정
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/tenten/damoa/post/dto/PostsQueryRes.java
+++ b/src/main/java/com/tenten/damoa/post/dto/PostsQueryRes.java
@@ -7,7 +7,7 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
-public class PostQueryRes {
+public class PostsQueryRes {
     private Long id;
     private String contentId;
     private SnsType type;
@@ -17,7 +17,7 @@ public class PostQueryRes {
     private int likeCount;
     private int shareCount;
 
-    public PostQueryRes(Post post) {
+    public PostsQueryRes(Post post) {
         this.id = post.getId();
         this.contentId = post.getContentId();
         this.type = post.getType();
@@ -25,6 +25,9 @@ public class PostQueryRes {
         this.viewCount = post.getViewCount();
         this.likeCount = post.getLikeCount();
         this.shareCount = post.getShareCount();
-        this.content = post.getContent();
+
+        // content 20자 제한
+        String content = post.getContent();
+        this.content = content.length() > 20 ? content.substring(0, 20) : content;
     }
 }

--- a/src/main/java/com/tenten/damoa/post/service/PostQueryService.java
+++ b/src/main/java/com/tenten/damoa/post/service/PostQueryService.java
@@ -2,6 +2,7 @@ package com.tenten.damoa.post.service;
 
 import com.tenten.damoa.post.domain.Post;
 import com.tenten.damoa.post.dto.PostQueryRes;
+import com.tenten.damoa.post.dto.PostsQueryRes;
 import com.tenten.damoa.post.repository.PostRepository;
 import com.tenten.damoa.post.specification.PostSpecification;
 import lombok.RequiredArgsConstructor;
@@ -49,7 +50,7 @@ public class PostQueryService {
     }
 
     @Transactional
-    public Page<PostQueryRes> getPosts(String tag, String type, String orderBy, String order, String searchBy, String search, int pageSize, int page) {
+    public Page<PostsQueryRes> getPosts(String tag, String type, String orderBy, String order, String searchBy, String search, int pageSize, int page) {
 
         Sort.Direction direction = "asc".equalsIgnoreCase(order) ? Sort.Direction.ASC : Sort.Direction.DESC;
         Pageable paging = PageRequest.of(page, pageSize, Sort.by(direction, orderBy));
@@ -74,6 +75,6 @@ public class PostQueryService {
         }
         Page<Post> postsPages = postRepository.findAll(spec, paging);
 
-        return postsPages.map(PostQueryRes::new);
+        return postsPages.map(PostsQueryRes::new);
     }
 }

--- a/src/main/java/com/tenten/damoa/post/service/PostQueryService.java
+++ b/src/main/java/com/tenten/damoa/post/service/PostQueryService.java
@@ -27,12 +27,14 @@ public class PostQueryService {
     private final InteractionHistoryRepository interactionHistoryRepository;
 
     @Transactional
-    public Post getPostDetail(Long id) {
+    public PostQueryRes getPostDetail(Long id) {
         Post post = postRepository.findById(id)
                 .orElseThrow(() -> new BusinessException(ErrorCode.BAD_REQUEST));
 
         post.increaseViewCount();
         postRepository.save(post);
+
+        PostQueryRes res= new PostQueryRes(post);
 
         //builder 패턴을 이용하여 객체(생성자) 생성
         InteractionHistory interactionHistory = InteractionHistory.builder()
@@ -43,7 +45,7 @@ public class PostQueryService {
 
 
         interactionHistoryRepository.save(interactionHistory);
-        return post;
+        return res;
     }
 
     @Transactional


### PR DESCRIPTION
## 🔥 구현 기능
> Post 엔티티에 hashtag_id 컬럼이 조인되면서, dto가 아닌 Post객체를 통째로 응답했을 때, 
**양방향 무한 참조** 문제가 발생한 것으로 확인되었습니다.
해결을 위해 엔티티를 반환하는 것이 아닌, dto 응답으로 수정하여 해결했습니다. 

## 🔥 구현 방법
PostQueryRes 사용

## 🔥 관련 이슈
related: #42 
    
## 참고 할만한 자료(선택)
https://vividswan.tistory.com/entry/JPA-%EC%96%91%EB%B0%A9%ED%96%A5-%EB%AC%B4%ED%95%9C-%EC%B0%B8%EC%A1%B0