### PR TITLE
[env] Jacoco 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -96,8 +96,8 @@ jacocoTestReport {
 			)
 		}
 
-		xml.destination file("${buildDir}/jacoco/index.xml")   // `build` 디렉토리에 리포트 파일 생성
-		html.destination file("${buildDir}/jacoco/index.html")
+		xml.destination file("${layout.buildDirectory.get().asFile}/jacoco/index.xml")   // `build` 디렉토리에 리포트 파일 생성
+		html.destination file("${layout.buildDirectory.get().asFile}/jacoco/index.html")
 	}
 }
 /** Jacoco end **/

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
 	id 'java'
 	id 'org.springframework.boot' version '3.3.2'
 	id 'io.spring.dependency-management' version '1.1.6'
+	id 'jacoco'
 }
 
 group = 'com.tenten'
@@ -56,6 +57,50 @@ dependencies {
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
 }
+
+jacoco {
+	toolVersion = "0.8.12"
+}
+
+test {
+	finalizedBy jacocoTestReport
+}
+
+jacocoTestReport {
+	dependsOn test // 테스트 이후에 수행
+
+	reports {
+		xml.required.set(true)
+		html.required.set(true)
+
+		// QueryDSL QDomain 제외시키기
+		def QDomains = []
+
+		for (qPattern in '**/QA'..'**/QZ') {
+			QDomains.add(qPattern + '*')
+		}
+		afterEvaluate {
+			classDirectories.setFrom(
+					files(classDirectories.files.collect {
+						fileTree(dir: it, excludes: [
+								"com/tenten/damoa/**/domain/**",
+								"**/*Application*",
+								"**/*Config*",
+								"**/*Req*",
+								"**/*Res*",
+								"**/*Interceptor*",
+								"**/*Exception*",
+								"**/*specification*"
+						] + QDomains)
+					})
+			)
+		}
+
+		xml.destination file("${buildDir}/jacoco/index.xml")   // `build` 디렉토리에 리포트 파일 생성
+		html.destination file("${buildDir}/jacoco/index.html")
+	}
+}
+/** Jacoco end **/
 
 tasks.named('test') {
 	useJUnitPlatform()


### PR DESCRIPTION
## 🔥 구현 기능
> 테스트 커버리지를 위한 Jacoco 설정을 적용했습니다.

## 🔥 구현 방법
Gradle에 플러그인 추가 및 테스트에서 제외할 파일(domain, dto 등) 작성  

**사용 방법:** `./gradlew test` 실행 시 build/jacoco/index.html/index.html에 **커버리지 보고서가 생성**됩니다.

![image](https://github.com/user-attachments/assets/ae0c2079-5bbd-4713-89b7-36e9fb180e95)


## 🔥 관련 이슈
related: #44
    
## 참고 할만한 자료(선택)
